### PR TITLE
End reaction fix + option for orienting beams

### DIFF
--- a/Examples/Double Beam - Point Load.py
+++ b/Examples/Double Beam - Point Load.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Sep 16 14:43:31 2018
+
+@author: craig
+"""
+# Example of a simply supported beam with a point load.
+# Units used in this example are metric (SI)
+
+import numpy as np
+
+# Import `FEModel3D` from `PyNite`
+from PyNite import FEModel3D
+
+# 1: No beam-reference point
+# 2: Ref @ [0,0,-10] - should match Case 1
+# 3: Ref @ [0,-10,0] - twists the beam through 90 degrees
+
+# *** Puzzle: Why do the node reactions flip upside down in Case 3 only? ***
+# (Actually, they go to zero for [0,-10,10].)
+
+case = 3
+
+if case == 1:
+    beamref = None
+if case == 2:
+    beamref = np.asarray([0,0,-10])
+if case == 3:
+    beamref = np.asarray([0,-10,0])
+
+# Create a new finite element model
+SimpleBeam = FEModel3D()
+
+# Add nodes (3 metres apart on x-axis)
+L = 3
+SimpleBeam.AddNode("N1", -L/2, 0, 0)
+SimpleBeam.AddNode("N2",  0,   0, 0)
+SimpleBeam.AddNode("N3",  L/2, 0, 0)
+
+# Add a beam with a solid rectangular section:
+E = 209E9  # Young's elastic modulus
+G = 79.3E9 # shear modulus
+b = 30E-2  # breadth (y-thickness)
+d = 1E-2   # depth   (z-thickness)
+Iyy = b * d**3 / 12 # 2nd moment of area
+Izz = b**3 * d / 12 # 2nd moment of area
+J = Iyy + Izz       # 2nd polar moment of area
+A = b * d           # cross-sectional area
+SimpleBeam.AddMember("M1", "N1", "N2", E, G, Iyy, Izz, J, A, beamref)
+SimpleBeam.AddMember("M2", "N2", "N3", E, G, Iyy, Izz, J, A, beamref)
+
+# Provide simple supports - can't displace or twist at either end
+SimpleBeam.DefineSupport("N1", True, True, True, True, False, False)
+SimpleBeam.DefineSupport("N3", True, True, True, True, False, False)
+
+# Add a point load at the midspan of the beam
+F = -1E3 # load, e.g., a hanging weight of approx 100 kg
+SimpleBeam.AddNodeLoad("N2", "FZ", F)
+
+# Expected moment
+M = -F * L / 4
+# Expected deflection
+if case == 3:
+    delta = F * L**3 / (48 * E * Izz)
+else:
+    delta = F * L**3 / (48 * E * Iyy)
+print('Expected deflection = {d:.2f} mm; max. bending moment = {m:.2f}'.format(d=(delta * 1E3), m=M))
+
+# Analyze the beam
+SimpleBeam.Analyze()
+print('Deflection from analysis = {d:.2f} mm'.format(d=(SimpleBeam.GetNode("N2").DZ * 1E3)))
+
+# Print the shear, moment, and deflection diagrams
+SimpleBeam.GetMember("M1").PlotShear("Fz")
+SimpleBeam.GetMember("M1").PlotMoment("My")
+SimpleBeam.GetMember("M1").PlotDeflection("dz")
+
+# Print reactions at each end of the beam
+print("Left Support Reaction: {Rxn:.2f} N".format(Rxn = SimpleBeam.GetNode("N1").RxnFZ))
+print("Right Support Reacton: {Rxn:.2f} N".format(Rxn = SimpleBeam.GetNode("N3").RxnFZ))

--- a/PyNite/FEModel3D.py
+++ b/PyNite/FEModel3D.py
@@ -50,7 +50,7 @@ class FEModel3D():
         self.__Nodes.append(newNode)
 
 #%%
-    def AddMember(self, Name, iNode, jNode, E, G, Iy, Iz, J, A):
+    def AddMember(self, Name, iNode, jNode, E, G, Iy, Iz, J, A, origin=None):
         """
         Adds a new member to the model.
         
@@ -74,10 +74,12 @@ class FEModel3D():
             The polar moment of inertia of the member.
         A : number
             The cross-sectional area of the member.
+        origin : numpy.array(3)
+            A reference point in the member's ZX-plane, not colinear with the member (optional).
         """
         
         # Create a new member
-        newMember = Member3D(Name, self.GetNode(iNode), self.GetNode(jNode), E, G, Iy, Iz, J, A)
+        newMember = Member3D(Name, self.GetNode(iNode), self.GetNode(jNode), E, G, Iy, Iz, J, A, origin)
         
         # Add the new member to the list
         self.__Members.append(newMember)

--- a/PyNite/Member3D.py
+++ b/PyNite/Member3D.py
@@ -367,14 +367,14 @@ class Member3D():
     def F(self):
         
         # Calculate and return the global force vector
-        return matmul(self.T(), self.f())
+        return matmul(transpose(self.T()), self.f())
     
 #%% 
     # Global fixed end reaction vector
     def FER(self):
         
         # Calculate and return the fixed end reaction vector
-        return matmul(self.T(), self.fer())
+        return matmul(transpose(self.T()), self.fer())
 
 #%%
     def D(self):

--- a/PyNite/Member3D.py
+++ b/PyNite/Member3D.py
@@ -5,6 +5,7 @@ Created on Thu Nov  2 18:04:56 2017
 @author: D. Craig Brinck, SE
 """
 # %%
+import numpy as np
 from numpy import zeros, matrix, transpose, add, subtract, matmul, insert
 from numpy.linalg import inv
 from PyNite.BeamSegment import BeamSegment
@@ -17,7 +18,7 @@ class Member3D():
 
 #%%
     # Constructor
-    def __init__(self, Name, iNode, jNode, E, G, Iy, Iz, J, A):
+    def __init__(self, Name, iNode, jNode, E, G, Iy, Iz, J, A, origin=None):
         
         self.Name = Name # A unique name for the member given by the user
         self.ID = None # Unique index number for the member assigned by the program
@@ -29,6 +30,8 @@ class Member3D():
         self.Iz = Iz # The z-axis moment of inertia
         self.J = J # The polar moment of inertia or torsional constant
         self.A = A # The cross-sectional area
+        self.__T = None # The transformation matrix; created on first use
+        self.origin = origin # A reference point in member-local zx-plane *** not colinear with member ***
         self.L = ((jNode.X-iNode.X)**2+(jNode.Y-iNode.Y)**2+(jNode.Z-iNode.Z)**2)**0.5 # Length of the element
         self.PtLoads = [] # A list of point loads & moments applied to the element (Direction, P, x) or (Direction, M, x)
         self.DistLoads = [] # A list of linear distributed loads applied to the element (Direction, w1, w2, x1, x2)
@@ -288,52 +291,70 @@ class Member3D():
 
 #%%
     def d(self):
-       """
-       Returns the member's local displacement vector
-       """
+        """
+        Returns the member's local displacement vector
+        """
 
-       # Calculate and return the local displacement vector
-       return matmul(self.T(), self.D())
+        # Calculate and return the local displacement vector
+        return matmul(self.T(), self.D())
+
+#%%  
+    # Direction cosines for transformation matrix
+    def __direction_cosines(self):
+        if self.origin is not None:
+            r1 = np.asarray([self.iNode.X, self.iNode.Y, self.iNode.Z])
+            r2 = np.asarray([self.jNode.X, self.jNode.Y, self.jNode.Z])
+
+            i = r2 - r1
+            j = np.cross(r1 - self.origin, r2 - self.origin) # origin must not be colinear with the nodes
+            k = np.cross(i, j)
+
+            dirCos = np.matrix([i / np.linalg.norm(i), j / np.linalg.norm(j), k / np.linalg.norm(k)])
+        else:
+            x1 = self.iNode.X
+            x2 = self.jNode.X
+            y1 = self.iNode.Y
+            y2 = self.jNode.Y
+            z1 = self.iNode.Z
+            z2 = self.jNode.Z
+            L = self.L
+        
+            # Calculate direction cosines for the transformation matrix
+            l = (x2-x1)/L
+            m = (y2-y1)/L
+            n = (z2-z1)/L
+            D = (l**2+m**2)**0.5
+        
+            if l == 0 and m == 0 and n > 0:
+                dirCos = matrix([[0, 0, 1],
+                                 [0, 1, 0],
+                                 [-1, 0, 0]])
+            elif l == 0 and m == 0 and n < 0:
+                dirCos = matrix([[0, 0, -1],
+                                 [0, 1, 0],
+                                 [1, 0, 0]])
+            else:
+                dirCos = matrix([[l, m, n],
+                                 [-m/D, l/D, 0],
+                                 [-l*n/D, -m*n/D, D]])
+        return dirCos
         
 #%%  
     # Transformation matrix
     def T(self):
-        
-        x1 = self.iNode.X
-        x2 = self.jNode.X
-        y1 = self.iNode.Y
-        y2 = self.jNode.Y
-        z1 = self.iNode.Z
-        z2 = self.jNode.Z
-        L = self.L
-        
-        # Calculate direction cosines for the transformation matrix
-        l = (x2-x1)/L
-        m = (y2-y1)/L
-        n = (z2-z1)/L
-        D = (l**2+m**2)**0.5
-        
-        if l == 0 and m == 0 and n > 0:
-            dirCos = matrix([[0, 0, 1],
-                             [0, 1, 0],
-                             [-1, 0, 0]])
-        elif l == 0 and m == 0 and n < 0:
-            dirCos = matrix([[0, 0, -1],
-                             [0, 1, 0],
-                             [1, 0, 0]])
-        else:
-            dirCos = matrix([[l, m, n],
-                             [-m/D, l/D, 0],
-                             [-l*n/D, -m*n/D, D]])
-        
-        # Build the transformation matrix
-        transMatrix = zeros((12, 12))
-        transMatrix[0:3, 0:3] = dirCos
-        transMatrix[3:6, 3:6] = dirCos
-        transMatrix[6:9, 6:9] = dirCos
-        transMatrix[9:12, 9:12] = dirCos
-        
-        return transMatrix
+
+        if self.__T is None:
+            dirCos = self.__direction_cosines()
+
+            # Build the transformation matrix
+            transMatrix = zeros((12, 12))
+            transMatrix[0:3,  0:3 ] = dirCos
+            transMatrix[3:6,  3:6 ] = dirCos
+            transMatrix[6:9,  6:9 ] = dirCos
+            transMatrix[9:12, 9:12] = dirCos
+            self.__T = transMatrix
+
+        return self.__T
 
 #%%
     # Member global stiffness matrix


### PR DESCRIPTION
I'm still trying to get my head around the maths of it, but:
1. A mechanism for orientating beams by specifying a reference point in the beam's ZX-plane.
2. Don't create the transformation matrix, T(), more than once.
3. I think T() needs to be transposed when transforming back to the global coordinate frame.