### PR TITLE
Update Member3D.py

### DIFF
--- a/PyNite/Member3D.py
+++ b/PyNite/Member3D.py
@@ -885,8 +885,7 @@ class Member3D():
         Member3D.__plt.xlabel('Location')
         Member3D.__plt.title('Member ' + self.Name)
         Member3D.__plt.show()
-
-        
+        return fig
         
 #%%
     def Torsion(self, x):


### PR DESCRIPTION
In order to save diagrams, new line of code is needed at the end of each _Plot....()_ method present in Member3D.py. For sake of semplicity, in this pull request I have modifed only PlotMoment() method; if you will be agree with me I'll finish to modify the modul.

With this new line of code, we can choose if save or not the figure by **savefig()** function which belongs to matplotlib library. 

Example:

##Import FEModel3D from PyNite
from PyNite import FEModel3D
from PyNite import Visualization


##Create a new finite element model
SimpleBeam = FEModel3D()
L=5 #m

##Creat a new folder for results
name = "Results"
SimpleBeam.makedir(name)

##Nodes 
SimpleBeam.AddNode("N1", 0, 0, 0)
SimpleBeam.AddNode("N2", L, 0, 0)
SimpleBeam.AddAuxNode("aN1",0,0,L/2)

##Beam (30x50 cm)
E=2.1e11 #N/m^2
G=1
Iy=0.001125 #m^4
Iz=0.003125 #m^4
J=1
A=0.15 #m^2

SimpleBeam.AddMember("M1", "N1", "N2",E,G,Iy,Iz,J,A,"aN1")

##Supports
SimpleBeam.DefineSupport("N1",True, True, True, True, False, False)
SimpleBeam.DefineSupport("N2",True, True, True, True, False, False)
view=Visualization.RenderModel(SimpleBeam,0.2)

##Loads
SimpleBeam.AddMemberPtLoad("M1","Fy",2000,L/2)#N e m

##Analysis
SimpleBeam.Analyze()

##Diagrams
SimpleBeam.GetMember("M1").PlotShear("Fy")
SimpleBeam.GetMember("M1").PlotMoment("Mz").savefig('{}/bending_moment.png'.format(name))

With this command I can choose the name and the format of image's file which will be stored in the results folder create before (#44 )

Thanks for attention again!