### PR TITLE
fix typo in Derivations/MITC4 Quad Element.ipynb

### DIFF
--- a/Derivations/MITC4 Quad Element.ipynb
+++ b/Derivations/MITC4 Quad Element.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "$\\epsilon = \\begin{bmatrix} \\epsilon_{xx} \\\\ \\epsilon_{yy} \\\\ \\gamma_{xy} \\end{bmatrix} = \\begin{bmatrix} \\frac{du}{dx} \\\\ \\frac{dv}{dy} \\\\ \\frac{du}{dy} + \\frac{dv}{dx}\\end{bmatrix} = [B_m][u] = \\begin{bmatrix} \\frac{dh_1}{dx} & 0 & \\frac{dh_2}{dx} & 0 & ... \\\\ 0 & \\frac{dh_1}{dy} & 0 & \\frac{dh_2}{dy} & ... \\\\ \\frac{dh_1}{dy} & \\frac{dh_1}{dx} & \\frac{dh_2}{dy} & \\frac{dh_2}{dx} & ... \\end{bmatrix} \\begin{bmatrix} u_1 \\\\ v_1 \\\\ u_2 \\\\ v_2 \\\\ . \\\\ . \\\\ . \\end{bmatrix}$\n",
     "\n",
-    "As before, to obtain the $[B_m]$ matrix, we can substitute in the terms from the follwing expression into the expression for $[B_m]$:"
+    "As before, to obtain the $[B_m]$ matrix, we can substitute in the terms from the following expression into the expression for $[B_m]$:"
    ]
   },
   {


### PR DESCRIPTION
Fix typo in: PyNite/Derivations/MITC4 Quad Element.ipynb

Step 5

from:
As before, to obtain the $[B_m]$ matrix, we can substitute in the terms from the **follwing** expression into the expression for $[B_m]$:

to:
As before, to obtain the $[B_m]$ matrix, we can substitute in the terms from the **following** expression into the expression for $[B_m]$: