### PR TITLE
Check for quads or plates before Rendering Contours.

### DIFF
--- a/PyNite/Member3D.py
+++ b/PyNite/Member3D.py
@@ -787,6 +787,10 @@ class Member3D():
                 
                 lastIndex = len(self.SegmentsZ) - 1
                 return self.SegmentsZ[lastIndex].moment(x - self.SegmentsZ[lastIndex].x1)
+                return self.SegmentsZ[lastIndex].Moment(x - self.SegmentsZ[lastIndex].x1)
+        
+        else:
+            raise ValueError(f"Direction must be 'My' or 'Mz'. {Direction} was given.")
             
 #%%
     def MaxMoment(self, Direction, combo_name='Combo 1'):

--- a/PyNite/Visualization.py
+++ b/PyNite/Visualization.py
@@ -188,8 +188,8 @@ def render_model(model, text_height=5, deformed_shape=False, deformed_scale=30,
     if (combo_name != None or case != None) and render_loads != False:
         _RenderLoads(model, renderer, text_height, combo_name, case)
     
-    # Render the plate and quad contours
-    if color_map != None:
+    # Render the plates and quads, if present
+    if model.Quads or model.Plates:
       _RenderContours(model, renderer, deformed_shape, deformed_scale, color_map, scalar_bar, combo_name)
 
     # Set the window's background to gray


### PR DESCRIPTION
I changed the check for `color_map` to check if the model has `Quads` or `Plates` directly. If the model does not have either `Quads` or `Plates` in it, rendering contours will fail with division by zero. This error occurs in `"Simple Beam - Point Load.py"` for example. I think this fix is clearer than checking `color_map` because it hits the root cause of the error. The `color_map` parameter is default=`None` in many places, which makes it easy to accidentally be set to `None`.

I also added a `ValueError` for the `Moment3D.moment` method, for invalid `Direction` arguments.

