### PR TITLE
Bug fix in setting num_quads for CylinderMesh

### DIFF
--- a/PyNite/Mesh.py
+++ b/PyNite/Mesh.py
@@ -1066,7 +1066,7 @@ class CylinderMesh(Mesh):
 
         # Determine the number of quads to mesh the circumference into
         if num_quads == None:
-            num_quads = int(2*pi/mesh_size)
+            num_quads = int(2*pi*self.radius/mesh_size)
 
         # Mesh the cylinder from the bottom toward the top
         while round(y, 10) < round(h, 10):


### PR DESCRIPTION
The calculation of `num_quads` using `mesh_size` now includes the radius. 

Before the change, if `mesh_size` > pi, the calculation comes up with `num_quads` = 0 or 1. As the program continues, it eventually fails somewhere else, with a ZeroDivisionError or similar error. Technically, this is due to a unit mismatch of rad/inch instead of inch/inch. The intended calculation is `2*pi*r/m`, not `2*pi/m`.

I think this is the only place this calculation happens this way.