### PR TITLE
Updated the outdated method names and keyword parameters in the Examples scripts, and in Member3D.

### DIFF
--- a/Examples/Beam on Elastic Foundation.py
+++ b/Examples/Beam on Elastic Foundation.py
@@ -61,7 +61,7 @@ boef.analyze(check_statics=True)
 
 # Render the mdoel with the deformed shape
 from PyNite.Visualization import render_model
-render_model(boef, text_height=1.5, deformed_shape=True)
+render_model(boef, annotation_size=1.5, deformed_shape=True)
 
 # Find and print the maximum displacement
 d_max = min([node.DY['Combo 1'] for node in boef.Nodes.values()])

--- a/Examples/Braced Frame - Spring Supported.py
+++ b/Examples/Braced Frame - Spring Supported.py
@@ -126,7 +126,7 @@ braced_frame.analyze()
 # Display the deformed shape of the structure magnified 50 times with the text
 # height 5 model units (inches) high.
 from PyNite import Visualization
-Visualization.render_model(braced_frame, text_height=5, deformed_shape=True,
+Visualization.render_model(braced_frame, annotation_size=5, deformed_shape=True,
                           deformed_scale=50, combo_name='1.2D+1.0W')
 
 # We should see upward displacement at N1 and downward displacement at N4 if

--- a/Examples/Braced Frame - Tension Only.py
+++ b/Examples/Braced Frame - Tension Only.py
@@ -105,7 +105,7 @@ BracedFrame.analyze()
 # Display the deformed shape of the structure magnified 50 times with the text
 # height 5 model units (inches) high
 from PyNite import Visualization
-Visualization.RenderModel(BracedFrame, text_height=5, deformed_shape=True,
+Visualization.render_model(BracedFrame, annotation_size=5, deformed_shape=True,
                           deformed_scale=50, combo_name='1.2D+1.0W')
 
 # Plot the axial load diagrams for the braces. We should see no compression on

--- a/Examples/Moment Frame - Lateral Load.py
+++ b/Examples/Moment Frame - Lateral Load.py
@@ -62,7 +62,7 @@ MomentFrame.analyze_PDelta(log=True)
 
 # Display the deformed shape of the structure magnified 50 times with the text height 5 model units (inches) high
 from PyNite import Visualization
-Visualization.RenderModel(MomentFrame, text_height=5, deformed_shape=True, deformed_scale=50, combo_name='1.2D+1.0W')
+Visualization.render_model(MomentFrame, annotation_size=5, deformed_shape=True, deformed_scale=50, combo_name='1.2D+1.0W')
 
 # Plot the moment diagram for the beam
 MomentFrame.Members['Beam'].plot_moment('Mz', combo_name='1.2D+1.0W')

--- a/Examples/Rectangular Plate Bending - Qauds.py
+++ b/Examples/Rectangular Plate Bending - Qauds.py
@@ -57,7 +57,7 @@ model.analyze(check_statics=True)
 
 # Render the wall. The quad mesh will be set to show 'Mx' results.
 from PyNite import Visualization
-Visualization.RenderModel(model, annotation_size=mesh_size/6, deformed_shape=False, combo_name='1.0W', color_map='Mx', render_loads=True)
+Visualization.render_model(model, annotation_size=mesh_size/6, deformed_shape=False, combo_name='1.0W', color_map='Mx', render_loads=True)
 
 # The it should be noted that the rendered contours are smoothed. Smoothing averages the corner
 # stresses from every quad framing into each node. This leads to a much more accurate contour.

--- a/Examples/Rectangular Tank Wall - Hydrostatic Loads.py
+++ b/Examples/Rectangular Tank Wall - Hydrostatic Loads.py
@@ -3,7 +3,7 @@
 # Import a few libraries from PyNite that we'll need
 from PyNite.FEModel3D import FEModel3D
 from PyNite.Mesh import RectangleMesh
-from PyNite.Visualization import RenderModel
+from PyNite.Visualization import render_model
 
 # Set material properties for the wall (4500 psi concrete)
 E = 57000*(4500)**0.5*12**2  # psf
@@ -69,7 +69,7 @@ model.add_load_combo('1.4F', {'F': 1.4})
 model.analyze(log=True, check_statics=True)
 
 # Render the model and plot the `Mx` moments.
-RenderModel(model, annotation_size=0.2, render_loads=True, deformed_shape=True, deformed_scale=500*10, color_map='Mx', combo_name='1.4F', labels=True)
+render_model(model, annotation_size=0.2, render_loads=True, deformed_shape=True, deformed_scale=500*10, color_map='Mx', combo_name='1.4F', labels=True)
 
 # Print the maximum and minumum displacements
 print('Max displacement: ', max([node.DZ['1.4F'] for node in model.Nodes.values()]))

--- a/Examples/Shear Wall with Openings.py
+++ b/Examples/Shear Wall with Openings.py
@@ -81,7 +81,7 @@ model.add_load_combo('Seismic', {'E': 1.0})
 model.analyze(log=True, check_statics=True)
 
 # Render the model and plot the `Txy` shears.
-# window = render_model(model, text_height=1, render_loads=True, deformed_shape=True,
+# window = render_model(model, annotation_size=1, render_loads=True, deformed_shape=True,
 #                       deformed_scale=200, color_map='Txy', scalar_bar=False,
 #                       combo_name='Seismic', labels=False, screenshot='console')
 from PyNite.Visualization import Renderer

--- a/Examples/Simple Beam - Point Load.py
+++ b/Examples/Simple Beam - Point Load.py
@@ -33,7 +33,7 @@ SimpleBeam.add_load_combo('1.2D+1.6L', {'D':1.2, 'L':1.6})
 # Analyze the beam and perform a statics check
 SimpleBeam.analyze(check_statics=True)
 
-Visualization.RenderModel(SimpleBeam, text_height=10, deformed_shape=True, deformed_scale=30, render_loads=True, combo_name='1.2D+1.6L')
+Visualization.render_model(SimpleBeam, annotation_size=10, deformed_shape=True, deformed_scale=30, render_loads=True, combo_name='1.2D+1.6L')
 
 # Print the shear, moment, and deflection diagrams
 SimpleBeam.Members['M1'].plot_shear('Fy', '1.2D+1.6L')

--- a/Examples/Simple Beam - Uniform Load.py
+++ b/Examples/Simple Beam - Uniform Load.py
@@ -40,4 +40,4 @@ print('Right Support Reacton:', SimpleBeam.Nodes['N2'].RxnFY, 'kip')
 
 # Render the deformed shape of the beam magnified 100 times, with a text height of 5 inches
 from PyNite import Visualization
-Visualization.RenderModel(SimpleBeam, text_height=5, deformed_shape=True, deformed_scale=100, render_loads=True)
+Visualization.render_model(SimpleBeam, annotation_size=5, deformed_shape=True, deformed_scale=100, render_loads=True)

--- a/Examples/Space Frame - Nodal Loads 1.py
+++ b/Examples/Space Frame - Nodal Loads 1.py
@@ -41,7 +41,7 @@ frame.add_node_load('N1', 'MX', -1000)
 frame.analyze(check_statics=True)
 
 # Render the deformed shape
-Visualization.RenderModel(frame, text_height=5, deformed_shape=True, deformed_scale=100, render_loads=True)
+Visualization.render_model(frame, annotation_size=5, deformed_shape=True, deformed_scale=100, render_loads=True)
 
 # Print the node 1 displacements
 print('Node 1 deformations:')

--- a/Examples/Space Frame - Nodal Loads 2.py
+++ b/Examples/Space Frame - Nodal Loads 2.py
@@ -44,4 +44,4 @@ print('Calculated results: ', frame.Nodes['N2'].DY, frame.Nodes['N3'].DZ)
 print('Expected results: ', -0.063, 1.825)
 
 # Render the model for viewing
-Visualization.RenderModel(frame, text_height=5, deformed_shape=True, deformed_scale=40, render_loads=True)
+Visualization.render_model(frame, annotation_size=5, deformed_shape=True, deformed_scale=40, render_loads=True)

--- a/Examples/Space Truss - Nodal Load.py
+++ b/Examples/Space Truss - Nodal Load.py
@@ -64,4 +64,4 @@ print('Member BE expected axial force: 112.1 Compression')
 # Render the model for viewing. The text height will be set to 50 mm.
 # Because the members in this example are nearly rigid, there will be virtually no deformation. The deformed shape won't be rendered.
 # The program has created a default load case 'Case 1' and a default load combo 'Combo 1' since we didn't specify any. We'll display 'Case 1'.
-Visualization.render_model(truss, text_height=0.05, render_loads=True, case='Case 1')
+Visualization.render_model(truss, annotation_size=0.05, render_loads=True, case='Case 1')

--- a/PyNite/Member3D.py
+++ b/PyNite/Member3D.py
@@ -724,7 +724,7 @@ class Member3D():
         # Calculate the shear diagram
         for i in range(21):
             x.append(self.L()/20*i)
-            V.append(self.Shear(Direction, self.L()/20*i, combo_name))
+            V.append(self.shear(Direction, self.L()/20*i, combo_name))
 
         Member3D.__plt.plot(x, V)
         Member3D.__plt.ylabel('Shear')


### PR DESCRIPTION
In the example scripts, it was references to `RenderModel` and the keyword change to `annotation_size`. In `Member3D`, there was an internal call to the deprecated `Shear` method.