### PR TITLE
merge_duplicate_nodes speed-up

### DIFF
--- a/PyNite/FEModel3D.py
+++ b/PyNite/FEModel3D.py
@@ -471,7 +471,8 @@ class FEModel3D():
         for element_attr in element_attrs:
             for element in getattr(self, element_attr).values():
                 for node_attr in node_attrs:
-                    if (node := getattr(element, node_attr, None)):
+                    node = getattr(element, node_attr, None)
+                    if node:
                         node_lookup[node].append((element, node_attr))
 
         # Make a copy of the `Nodes` dictionary

--- a/PyNite/Member3D.py
+++ b/PyNite/Member3D.py
@@ -63,12 +63,8 @@ class Member3D():
         Returns the length of the member.
         '''
 
-        # Get the i-node and the j-node for the member
-        i_node = self.i_node
-        j_node = self.j_node
-
         # Return the distance between the two nodes
-        return ((j_node.X-i_node.X)**2+(j_node.Y-i_node.Y)**2+(j_node.Z-i_node.Z)**2)**0.5
+        return self.i_node.distance(self.j_node)
 
 #%%
     def _aux_list(self):

--- a/PyNite/Node3D.py
+++ b/PyNite/Node3D.py
@@ -63,3 +63,14 @@ class Node3D():
 
         # Initialize the color contour value for the node. This will be used for contour smoothing.
         self.contour = []
+
+    def distance(self, other):
+        """
+        Returns the distance to another node.
+
+        Parameters
+        ----------
+        other : Node3D
+            A node object to compare coordinates with.
+        """
+        return ((self.X - other.X)**2 + (self.Y - other.Y)**2 + (self.Z - other.Z)**2)**0.5

--- a/PyNite/Plate3D.py
+++ b/PyNite/Plate3D.py
@@ -60,13 +60,13 @@ class Plate3D():
         """
         Returns the width of the plate along its local x-axis
         """
-        return ((self.j_node.X - self.i_node.X)**2 + (self.j_node.Y - self.i_node.Y)**2 + (self.j_node.Z - self.i_node.Z)**2)**0.5
+        return self.i_node.distance(self.j_node)
 
     def height(self):
         """
         Returns the height of the plate along its local y-axis
         """
-        return ((self.n_node.X - self.i_node.X)**2 + (self.n_node.Y - self.i_node.Y)**2 + (self.n_node.Z - self.i_node.Z)**2)**0.5
+        return self.i_node.distance(self.n_node)
     
     def Dm(self):
         """

--- a/PyNite/Spring3D.py
+++ b/PyNite/Spring3D.py
@@ -41,12 +41,8 @@ class Spring3D():
         Returns the length of the spring.
         '''
 
-        # Get the i-node and the j-node for the spring
-        i_node = self.i_node
-        j_node = self.j_node
-
         # Return the distance between the two nodes
-        return ((j_node.X-i_node.X)**2+(j_node.Y-i_node.Y)**2+(j_node.Z-i_node.Z)**2)**0.5
+        return self.i_node.distance(self.j_node)
 
 #%%
     def k(self):


### PR DESCRIPTION
Current method iterates through all elements (members/springs/plates/quads) on every pass comparing nodes. 

In this pr, node usage is checked ahead of time to reduce runtime.
Tested with 50000 nodes and 200 elements and noted a substantially reduction in runtime (~45 sec to ~8 sec on my machine).
Also added a new method to the Node3D class (`Node3d.distance`) to calculate the distance to a secondary node.