### PR TITLE
Speedup repair method

### DIFF
--- a/Examples/Braced Frame - Repair Usage.py
+++ b/Examples/Braced Frame - Repair Usage.py
@@ -85,8 +85,9 @@ f.add_member_pt_load(
 # Clean-up
 f.repair(
     merge_duplicates=True,  # must be run to avoid duplicate nodes
-    tolerance=1e-3,  # maximum 3d distance between coordinates to determine duplicate node
-    )  # maximum 3d distance between lines to determine member intersection
+    tolerance_node_distance=1e-3,  # maximum 3d distance between coordinates to determine duplicate node
+    tolerance_intersection=1e-3,  # analagous to minimum intersection angle; equivalent to sin-1(angle)
+    )
 
 # Analyze
 f.analyze(log=False, check_statics=True)


### PR DESCRIPTION
1) Fixes [this](https://github.com/JWock82/PyNite/pull/125#issuecomment-1096798356).
I split up the `tolerance` kwarg in the `repair` method and set a maximum value for the tolerance in the `intersection_virtual` method to fix this issue.
2) Speeds up repair method by skipping duplicate vector calculations (these are expensive). 
Tested using 25-100 horizontal and 25-100 vertical members with good results; I was seeing 20-38% reduction in runtime.
3) Added some annotation in the `repair` method so it is easier to follow the logic. 
4) Change some naming.