### PR TITLE
Fix reporting template methods

### DIFF
--- a/PyNite/Report_Template.html
+++ b/PyNite/Report_Template.html
@@ -284,16 +284,16 @@
                     <td>{{ combo }}</td>
                     <td>{{ "%.4g" | format(member.axial(0, combo)) }}</td>
                     <td>{{ "%.4g" | format(member.axial(member.L(), combo)) }}</td>
-                    <td>{{ "%.4g" | format(member.Shear("Fy", 0, combo)) }}</td>
-                    <td>{{ "%.4g" | format(member.Shear("Fz", 0, combo)) }}</td>
-                    <td>{{ "%.4g" | format(member.Shear("Fy", member.L(), combo)) }}</td>
-                    <td>{{ "%.4g" | format(member.Shear("Fz", member.L(), combo)) }}</td>
+                    <td>{{ "%.4g" | format(member.shear("Fy", 0, combo)) }}</td>
+                    <td>{{ "%.4g" | format(member.shear("Fz", 0, combo)) }}</td>
+                    <td>{{ "%.4g" | format(member.shear("Fy", member.L(), combo)) }}</td>
+                    <td>{{ "%.4g" | format(member.shear("Fz", member.L(), combo)) }}</td>
                     <td>{{ "%.4g" | format(member.moment("My", 0, combo)) }}</td>
                     <td>{{ "%.4g" | format(member.moment("Mz", 0, combo)) }}</td>
                     <td>{{ "%.4g" | format(member.moment("My", member.L(), combo)) }}</td>
                     <td>{{ "%.4g" | format(member.moment("Mz", member.L(), combo)) }}</td>
-                    <td>{{ "%.4g" | format(member.Torsion(0, combo)) }}</td>
-                    <td>{{ "%.4g" | format(member.Torsion(member.L(), combo)) }}</td>
+                    <td>{{ "%.4g" | format(member.torque(0, combo)) }}</td>
+                    <td>{{ "%.4g" | format(member.torque(member.L(), combo)) }}</td>
                 </tr>
                 {% endfor %}
             {% endfor %}


### PR DESCRIPTION
The reporting template does not work in its current state, since it is using the `member.Shear` and `member.Torsion` methods.
This PR updates the template to use `member.shear` and `member.torque` in place.