### PR TITLE
Update parameter names in FEModel3D methods for consistency of API

### DIFF
--- a/PyNite/FEModel3D.py
+++ b/PyNite/FEModel3D.py
@@ -982,9 +982,9 @@ class FEModel3D():
         :raises ValueError: _description_
         """
             
-        # Validate the value of Direction
+        # Validate the value of direction
         if direction not in ('DX', 'DY', 'DZ', 'RX', 'RY', 'RZ'):
-            raise ValueError(f"Direction must be 'DX', 'DY', 'DZ', 'RX', 'RY', or 'RZ'. {direction} was given.")
+            raise ValueError(f"direction must be 'DX', 'DY', 'DZ', 'RX', 'RY', or 'RZ'. {direction} was given.")
         # Get the node
         node = self.Nodes[node_name]
 
@@ -1004,11 +1004,11 @@ class FEModel3D():
         # Flag the model as unsolved
         self.solution = None
 
-    def def_releases(self, Member, Dxi=False, Dyi=False, Dzi=False, Rxi=False, Ryi=False, Rzi=False, Dxj=False, Dyj=False, Dzj=False, Rxj=False, Ryj=False, Rzj=False):
+    def def_releases(self, member_name, Dxi=False, Dyi=False, Dzi=False, Rxi=False, Ryi=False, Rzi=False, Dxj=False, Dyj=False, Dzj=False, Rxj=False, Ryj=False, Rzj=False):
         """Defines member end realeses for a member. All member end releases will default to unreleased unless specified otherwise.
 
-        :param Member: The name of the member to have its releases modified.
-        :type Member: str
+        :param member_name: The name of the member to have its releases modified.
+        :type member_name: str
         :param Dxi: Indicates whether the member is released axially at its start. Defaults to False.
         :type Dxi: bool, optional
         :param Dyi: Indicates whether the member is released for shear in the local y-axis at its start. Defaults to False.
@@ -1036,7 +1036,7 @@ class FEModel3D():
         """
         
         # Apply the end releases to the member
-        self.Members[Member].Releases = [Dxi, Dyi, Dzi, Rxi, Ryi, Rzi, Dxj, Dyj, Dzj, Rxj, Ryj, Rzj]     
+        self.Members[member_name].Releases = [Dxi, Dyi, Dzi, Rxi, Ryi, Rzi, Dxj, Dyj, Dzj, Rxj, Ryj, Rzj]     
 
         # Flag the model as unsolved
         self.solution = None
@@ -1061,14 +1061,14 @@ class FEModel3D():
         # Flag the model as solved
         self.solution = None
 
-    def add_node_load(self, Node, Direction, P, case='Case 1'):
+    def add_node_load(self, node_name, direction, P, case='Case 1'):
         """Adds a nodal load to the model.
 
-        :param Node: The name of the node where the load is being applied.
-        :type Node: str
-        :param Direction: The global direction the load is being applied in. Forces are `'FX'`,
+        :param node_name: The name of the node where the load is being applied.
+        :type node_name: str
+        :param direction: The global direction the load is being applied in. Forces are `'FX'`,
                           `'FY'`, and `'FZ'`. Moments are `'MX'`, `'MY'`, and `'MZ'`.
-        :type Direction: str
+        :type direction: str
         :param P: The numeric value (magnitude) of the load.
         :type P: float
         :param case: The name of the load case the load belongs to. Defaults to 'Case 1'.
@@ -1076,26 +1076,26 @@ class FEModel3D():
         :raises ValueError: Occurs when an invalid load direction was specified.
         """
         
-        # Validate the value of Direction
-        if Direction not in ('FX', 'FY', 'FZ', 'MX', 'MY', 'MZ'):
-            raise ValueError(f"Direction must be 'FX', 'FY', 'FZ', 'MX', 'MY', or 'MZ'. {Direction} was given.")
+        # Validate the value of direction
+        if direction not in ('FX', 'FY', 'FZ', 'MX', 'MY', 'MZ'):
+            raise ValueError(f"direction must be 'FX', 'FY', 'FZ', 'MX', 'MY', or 'MZ'. {direction} was given.")
         # Add the node load to the model
-        self.Nodes[Node].NodeLoads.append((Direction, P, case))
+        self.Nodes[node_name].NodeLoads.append((direction, P, case))
 
         # Flag the model as unsolved
         self.solution = None
 
-    def add_member_pt_load(self, Member, Direction, P, x, case='Case 1'):
+    def add_member_pt_load(self, member_name, direction, P, x, case='Case 1'):
         """Adds a member point load to the model.
 
-        :param Member: The name of the member the load is being applied to.
-        :type Member: str
-        :param Direction: The direction in which the load is to be applied. Valid values are `'Fx'`,
+        :param member_name: The name of the member the load is being applied to.
+        :type member_name: str
+        :param direction: The direction in which the load is to be applied. Valid values are `'Fx'`,
                           `'Fy'`, `'Fz'`, `'Mx'`, `'My'`, `'Mz'`, `'FX'`, `'FY'`, `'FZ'`, `'MX'`, `'MY'`, or `'MZ'`.
                           Note that lower-case notation indicates use of the beam's local
                           coordinate system, while upper-case indicates use of the model's globl
                           coordinate system.
-        :type Direction: str
+        :type direction: str
         :param P: The numeric value (magnitude) of the load.
         :type P: float
         :param x: The load's location along the member's local x-axis.
@@ -1105,27 +1105,27 @@ class FEModel3D():
         :raises ValueError: Occurs when an invalid load direction has been specified.
         """            
 
-        # Validate the value of Direction
-        if Direction not in ('Fx', 'Fy', 'Fz', 'FX', 'FY', 'FZ', 'Mx', 'My', 'Mz', 'MX', 'MY', 'MZ'):
-            raise ValueError(f"Direction must be 'Fx', 'Fy', 'Fz', 'FX', 'FY', FZ', 'Mx', 'My', 'Mz', 'MX', 'MY', or 'MZ'. {Direction} was given.")
+        # Validate the value of direction
+        if direction not in ('Fx', 'Fy', 'Fz', 'FX', 'FY', 'FZ', 'Mx', 'My', 'Mz', 'MX', 'MY', 'MZ'):
+            raise ValueError(f"direction must be 'Fx', 'Fy', 'Fz', 'FX', 'FY', FZ', 'Mx', 'My', 'Mz', 'MX', 'MY', or 'MZ'. {direction} was given.")
         
         # Add the point load to the member
-        self.Members[Member].PtLoads.append((Direction, P, x, case))
+        self.Members[member_name].PtLoads.append((direction, P, x, case))
         
         # Flag the model as unsolved
         self.solution = None
 
-    def add_member_dist_load(self, member_name, Direction, w1, w2, x1=None, x2=None, case='Case 1'):
+    def add_member_dist_load(self, member_name, direction, w1, w2, x1=None, x2=None, case='Case 1'):
         """Adds a member distributed load to the model.
 
         :param member_name: The name of the member the load is being appied to.
         :type member_name: str
-        :param Direction: The direction in which the load is to be applied. Valid values are `'Fx'`,
+        :param direction: The direction in which the load is to be applied. Valid values are `'Fx'`,
                           `'Fy'`, `'Fz'`, `'FX'`, `'FY'`, or `'FZ'`.
                           Note that lower-case notation indicates use of the beam's local
                           coordinate system, while upper-case indicates use of the model's globl
                           coordinate system.
-        :type Direction: str
+        :type direction: str
         :param w1: The starting value (magnitude) of the load.
         :type w1: float
         :param w2: The ending value (magnitude) of the load.
@@ -1141,9 +1141,9 @@ class FEModel3D():
         :raises ValueError: Occurs when an invalid load direction has been specified.
         """
        
-        # Validate the value of Direction
-        if Direction not in ('Fx', 'Fy', 'Fz', 'FX', 'FY', 'FZ'):
-            raise ValueError(f"Direction must be 'Fx', 'Fy', 'Fz', 'FX', 'FY', or 'FZ'. {Direction} was given.")
+        # Validate the value of direction
+        if direction not in ('Fx', 'Fy', 'Fz', 'FX', 'FY', 'FZ'):
+            raise ValueError(f"direction must be 'Fx', 'Fy', 'Fz', 'FX', 'FY', or 'FZ'. {direction} was given.")
         # Determine if a starting and ending points for the load have been specified.
         # If not, use the member start and end as defaults
         if x1 == None:
@@ -1157,7 +1157,7 @@ class FEModel3D():
             end = x2
 
         # Add the distributed load to the member
-        self.Members[member_name].DistLoads.append((Direction, w1, w2, start, end, case))
+        self.Members[member_name].DistLoads.append((direction, w1, w2, start, end, case))
         
         # Flag the model as unsolved
         self.solution = None


### PR DESCRIPTION
Hi @JWock82,

I noticed that there were some breaking changes to the API with recent versions but that the updates were not applied to all of the methods in `FEModel3D`. I have updated the rest of the parameter names across the `FEModel3D` object by following what seemed to be the desired new convention. Here is how I understand it:

* When creating a new object (e.g. node, member, section, etc.), the method that creates it (e.g. `.add_node`) will accept a parameter called `name` to set the name of the object in the model.
* When creating an assignment to an existing object (e.g. a load to a member), then the parameter will be named something like `member_name` (as opposed to `Member`) to make it clear that this parameter is to accept a name and not a `Member` object itself.

I ran the test suite and all tests pass. However, I notice that the test suite does not use any keyword arguments when the methods are called. The tests passing will reflect that the parameter name changes I made in the function signatures have been updated in the function implementations and not that I have followed the naming convention perfectly (although, from manual review, I think I have).

Let me know your thoughts on this?