### PR TITLE
Added check and conversion for non-numerical data coming in to sig_fig_round

### DIFF
--- a/PyNite/Rendering.py
+++ b/PyNite/Rendering.py
@@ -1250,6 +1250,13 @@ def _PrepContour(model, stress_type='Mx', combo_name='Combo 1'):
                 node.contour = sum(node.contour)/len(node.contour)
 
 def sig_fig_round(number, sig_figs):
+    # Check for strings or other convertible data types
+    if not isinstance(number, (float, int)):
+        try:
+            number = float(number)
+        except:
+            raise ValueError(f"{number} is not a number. Ensure that all labels are numeric.")
+
     if number == 0:
         return 0
 


### PR DESCRIPTION
I tried running the new version to see the new PyVista display. It took some work. Once I got the installs figured out, I found that there seemed to be a bug in the function `sig_fig_round`. It was being passed a `text_label` and it was trying to perform math functions on the value. It seemed that a conversion step was necessary to convert the `text_label` to a `float`. 

I added the conversion into `sig_fig_round` and then the display worked. And...it looks nice! I love that it is not spawning a separate process that hangs your kernel like VTK does. Thank you!