### PR TITLE
Enforce Use of Section Properties

### DIFF
--- a/Examples/Beam on Elastic Foundation.py
+++ b/Examples/Beam on Elastic Foundation.py
@@ -38,14 +38,16 @@ E = 29000   # ksi
 G = 11200   # ksi
 boef.add_material('Steel', E, G, 0.3, 490/1000/12**3)
 
-# Define section properties (W8x35)
+# Define section properties (W8x35) and add a section to the model
 A = 10.3    # in^2
 Iz = 127    # in^4 (strong axis)
 Iy = 42.6   # in^4 (weak axis)
 J = 0.769   # in^4
 
+boef.add_section('W8x35', A, Iy, Iz, J)
+
 # Define the member
-boef.add_member('M1', 'N1', 'N' + str(num_nodes), 'Steel', Iy, Iz, J, A)
+boef.add_member('M1', 'N1', 'N' + str(num_nodes), 'Steel', 'W8x35')
 
 # In the next few lines no load case or load combination is being specified. When this is the case,
 # PyNite internally creates a default load case ('Case 1') and a default load combination

--- a/Examples/Braced Frame - Spring Supported.py
+++ b/Examples/Braced Frame - Spring Supported.py
@@ -13,11 +13,12 @@ braced_frame.add_node('N2', 0, 12*12, 0)
 braced_frame.add_node('N3', 15*12, 12*12, 0)
 braced_frame.add_node('N4', 15*12, 0*12, 0)
 
-# Define column properties (use W10x33 from the AISC Manual):
+# Define column properties (use W10x33 from the AISC Manual) and add section to the model:
 Iy = 36.6 # in^4
 Iz = 171  # in^4
 J = 0.58  # in^4
 A = 9.71  # in^2
+braced_frame.add_section('W10x33', A, Iy, Iz, J)
 
 # Define a material
 E = 29000 # Young's modulus (ksi)
@@ -27,29 +28,31 @@ rho = 0.490/12**2  # Density (kci)
 braced_frame.add_material('Steel', E, G, nu, rho)
 
 # Define the columns
-braced_frame.add_member('Col1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-braced_frame.add_member('Col2', 'N4', 'N3', 'Steel', Iy, Iz, J, A)
+braced_frame.add_member('Col1', 'N1', 'N2', 'Steel', 'W10x33')
+braced_frame.add_member('Col2', 'N4', 'N3', 'Steel', 'W10x33')
 
-# Define beam properties (Use W8x24)
+# Define beam properties (Use W8x24) and add section to the model
 Iy = 18.3 # in^4
 Iz = 82.7 # in^4
 J = 0.346 # in^4
 A = 7.08 # in^2
+braced_frame.add_section('W8x24', A, Iy, Iz, J)
 
 # Define the beams
-braced_frame.add_member('Beam', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
+braced_frame.add_member('Beam', 'N2', 'N3', 'Steel', 'W8x24')
 braced_frame.def_releases('Beam', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
 
 # Define the brace properties
 # We'll use a section with L/r <= 300 which is a common rule of thumb for
-# tension members. We'll use L4x4x1/4.
+# tension members. We'll use L4x4x1/4. 
 Iy = 3 # in^4
 Iz = 3 # in^4
 J = 0.0438 # in^4
 A = 1.94 # in^2
+braced_frame.add_section('L4x4x1/4', A, Iy, Iz, J)
 
 # Define a brace (tension and compression - both ways)
-braced_frame.add_member('Brace1', 'N1', 'N3', 'Steel', Iy, Iz, J, A)
+braced_frame.add_member('Brace1', 'N1', 'N3', 'Steel', 'L4x4x1/4')
 
 # Let's add spring supports to the base of the structure. We'll add a couple of
 # extra nodes at the base of the structure that will receive the springs. The

--- a/Examples/Braced Frame - Tension Only.py
+++ b/Examples/Braced Frame - Tension Only.py
@@ -18,6 +18,7 @@ Iy = 36.6 # in^4
 Iz = 171 # in^4
 J = 0.58 # in^4
 A = 9.71 # in^2
+braced_frame.add_section('W10x33', A, Iy, Iz, J)
 
 # Define a material
 E = 29000 # ksi
@@ -27,17 +28,18 @@ rho = 0.490/12**2  # Density (kci)
 braced_frame.add_material('Steel', E, G, nu, rho)
 
 # Define the columns
-braced_frame.add_member('Col1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-braced_frame.add_member('Col2', 'N4', 'N3', 'Steel', Iy, Iz, J, A)
+braced_frame.add_member('Col1', 'N1', 'N2', 'Steel', 'W10x33')
+braced_frame.add_member('Col2', 'N4', 'N3', 'Steel', 'W10x33')
 
 # Define beam properties (Use W8x24)
 Iy = 18.3 # in^4
 Iz = 82.7 # in^4
 J = 0.346 # in^4
 A = 7.08 # in^2
+braced_frame.add_section('W8x24', A, Iy, Iz, J)
 
 # Define the beams
-braced_frame.add_member('Beam', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
+braced_frame.add_member('Beam', 'N2', 'N3', 'Steel', 'W8x24')
 braced_frame.def_releases('Beam', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
 
 # Define the brace properties
@@ -47,12 +49,11 @@ Iy = 3 # in^4
 Iz = 3 # in^4
 J = 0.0438 # in^4
 A = 1.94 # in^2
+braced_frame.add_section('L4x4x1/4', A, Iy, Iz, J)
 
 # Define the braces
-braced_frame.add_member('Brace1', 'N1', 'N3', 'Steel', Iy, Iz, J, A,
-                      tension_only=True)
-braced_frame.add_member('Brace2', 'N4', 'N2', 'Steel', Iy, Iz, J, A,
-                      tension_only=True)
+braced_frame.add_member('Brace1', 'N1', 'N3', 'Steel', 'L4x4x1/4', tension_only=True)
+braced_frame.add_member('Brace2', 'N4', 'N2', 'Steel', 'L4x4x1/4', tension_only=True)
 
 # Release the brace ends to form an axial member
 braced_frame.def_releases('Brace1', Ryi=True, Rzi=True, Ryj=True, Rzj=True)

--- a/Examples/Moment Frame - Lateral Load.py
+++ b/Examples/Moment Frame - Lateral Load.py
@@ -18,6 +18,7 @@ Iy = 36.6 # in^4
 Iz = 171 # in^4
 J = 0.58 # in^4
 A = 9.71 # in^2
+MomentFrame.add_section('W10x33', A, Iy, Iz, J)
 
 # Define a material
 E = 29000 # ksi
@@ -27,17 +28,18 @@ rho = 0.490/12**3  # Density (kci)
 MomentFrame.add_material('Steel', E, G, nu, rho)
 
 # Define the columns
-MomentFrame.add_member('Col1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-MomentFrame.add_member('Col2', 'N4', 'N3', 'Steel', Iy, Iz, J, A)
+MomentFrame.add_member('Col1', 'N1', 'N2', 'Steel', 'W10x33')
+MomentFrame.add_member('Col2', 'N4', 'N3', 'Steel', 'W10x33')
 
 # Define beam properties (Use W8x24)
 Iy = 18.3 # in^4
 Iz = 82.7 # in^4
 J = 0.346 # in^4
 A = 7.08 # in^2
+MomentFrame.add_section('W8x24', A, Iy, Iz, J)
 
 # Define the beams
-MomentFrame.add_member('Beam', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
+MomentFrame.add_member('Beam', 'N2', 'N3', 'Steel', 'W8x24')
 
 # Provide fixed supports at the bases of the columns
 MomentFrame.def_support('N1', support_DX=True, support_DY=True, support_DZ=True, support_RX=True, support_RY=True, support_RZ=True)

--- a/Examples/P-Delta Analysis.py
+++ b/Examples/P-Delta Analysis.py
@@ -23,8 +23,9 @@ for i in range(num_nodes):
     # Add nodes
     cantilever.add_node('N' + str(i+1), 0, i*L/(num_nodes - 1), 0)
 
-# Add the member
-cantilever.add_member('M1', 'N1', 'N6', 'Steel', I, I, 200/12**4, 10/12**2)
+# Add the section and member
+cantilever.add_section('MySection', 10/12**2, I, I, 200/12**4)
+cantilever.add_member('M1', 'N1', 'N6', 'Steel',  'MySection')
 
 # Add a fixed support at the base of the column
 cantilever.def_support('N1', True, True, True, True, True, True)

--- a/Examples/Simple Beam - Factored Envelope.py
+++ b/Examples/Simple Beam - Factored Envelope.py
@@ -22,9 +22,12 @@ nu = 0.3        # Poisson's ratio
 rho = 2.836e-4  # Density (kci)
 simple_beam.add_material('Steel', E, G, nu, rho)
 
-# Add a beam with the following properties:
+# Add a section with the following properties:
 # Iy = 100 in^4, Iz = 150 in^4, J = 250 in^4, A = 20 in^2
-simple_beam.add_member('M1', 'N1', 'N2', 'Steel', 100, 150, 250, 20)
+simple_beam.add_section('MySection', 20, 100, 150, 250)
+
+#Add member
+simple_beam.add_member('M1', 'N1', 'N2', 'Steel', 'MySection')
 
 # Provide simple supports
 simple_beam.def_support('N1', True, True, True, True, False, False)  # Constrained for torsion at 'N1'

--- a/Examples/Simple Beam - Point Load.py
+++ b/Examples/Simple Beam - Point Load.py
@@ -21,9 +21,12 @@ nu = 0.3        # Poisson's ratio
 rho = 2.836e-4  # Density (kci)
 simple_beam.add_material('Steel', E, G, nu, rho)
 
-# Add a beam with the following properties:
+# Add a section with the following properties:
 # Iy = 100 in^4, Iz = 150 in^4, J = 250 in^4, A = 20 in^2
-simple_beam.add_member('M1', 'N1', 'N2', 'Steel', 100, 150, 250, 20)
+simple_beam.add_section('MySection', 20, 100, 150, 250)
+
+#Add member
+simple_beam.add_member('M1', 'N1', 'N2', 'Steel', 'MySection')
 
 # Provide simple supports
 simple_beam.def_support('N1', True, True, True, True, False, False)  # Constrained for torsion at 'N1'

--- a/Examples/Simple Beam - Uniform Load.py
+++ b/Examples/Simple Beam - Uniform Load.py
@@ -19,9 +19,12 @@ nu = 0.3        # Poisson's ratio
 rho = 2.836e-4  # Density (kci)
 simple_beam.add_material('Steel', E, G, nu, rho)
 
-# Add a beam with the following properties:
+# Add a section with the following properties:
 # Iy = 100 in^4, Iz = 150 in^4, J = 250 in^4, A = 20 in^2
-simple_beam.add_member('M1', 'N1', 'N2', 'Steel', 100, 150, 250, 20)
+simple_beam.add_section('MySection', 20, 100, 150, 250)
+
+#Add member
+simple_beam.add_member('M1', 'N1', 'N2', 'Steel', 'MySection')
 
 # Provide simple supports
 simple_beam.def_support('N1', True, True, True, False, False, False)

--- a/Examples/Space Frame - Nodal Loads 1.py
+++ b/Examples/Space Frame - Nodal Loads 1.py
@@ -26,6 +26,7 @@ J = 50
 Iy = 100
 Iz = 100
 A = 10
+frame.add_section('MySection', A, Iy, Iz, J)
 
 # Define a material
 E = 30000
@@ -34,9 +35,9 @@ nu = 0.3
 rho = 2.836e-4
 frame.add_material('Steel', E, G, nu, rho)
 
-frame.add_member('M1', 'N2', 'N1', 'Steel', Iy, Iz, J, A)
-frame.add_member('M2', 'N3', 'N1', 'Steel', Iy, Iz, J, A)
-frame.add_member('M3', 'N4', 'N1', 'Steel', Iy, Iz, J, A)
+frame.add_member('M1', 'N2', 'N1', 'Steel', 'MySection')
+frame.add_member('M2', 'N3', 'N1', 'Steel', 'MySection')
+frame.add_member('M3', 'N4', 'N1', 'Steel', 'MySection')
 
 # Add nodal loads
 frame.add_node_load('N1', 'FY', -50)

--- a/Examples/Space Frame - Nodal Loads 2.py
+++ b/Examples/Space Frame - Nodal Loads 2.py
@@ -25,6 +25,7 @@ J = 100
 Iy = 200
 Iz = 1000
 A = 100
+frame.add_section('MySection', A, Iy, Iz, J)
 
 # Define a material
 E = 30000
@@ -33,9 +34,9 @@ nu = 0.3
 rho = 2.836e-4
 frame.add_material('Steel', E, G, nu, rho)
 
-frame.add_member('M12', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-frame.add_member('M23', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
-frame.add_member('M34', 'N3', 'N4', 'Steel', Iy, Iz, J, A)
+frame.add_member('M12', 'N1', 'N2', 'Steel', 'MySection')
+frame.add_member('M23', 'N2', 'N3', 'Steel', 'MySection')
+frame.add_member('M34', 'N3', 'N4', 'Steel', 'MySection')
 
 # Add nodal loads
 frame.add_node_load('N2', 'FY', -5)

--- a/Examples/Space Truss - Nodal Load.py
+++ b/Examples/Space Truss - Nodal Load.py
@@ -30,14 +30,16 @@ nu = 0.3
 rho = 1
 truss.add_material('Rigid', E, G, nu, rho)
 
+#Add a section to use for all members in this model
+truss.add_section('TrussSection', 100, 100, 100, 100)
 
 # Create members
-truss.add_member('AB', 'A', 'B', 'Rigid', 100, 100, 100, 100)
-truss.add_member('AC', 'A', 'C', 'Rigid', 100, 100, 100, 100)
-truss.add_member('AD', 'A', 'D', 'Rigid', 100, 100, 100, 100)
-truss.add_member('BC', 'B', 'C', 'Rigid', 100, 100, 100, 100)
-truss.add_member('BD', 'B', 'D', 'Rigid', 100, 100, 100, 100)
-truss.add_member('BE', 'B', 'E', 'Rigid', 100, 100, 100, 100)
+truss.add_member('AB', 'A', 'B', 'Rigid', 'TrussSection')
+truss.add_member('AC', 'A', 'C', 'Rigid', 'TrussSection')
+truss.add_member('AD', 'A', 'D', 'Rigid', 'TrussSection')
+truss.add_member('BC', 'B', 'C', 'Rigid', 'TrussSection')
+truss.add_member('BD', 'B', 'D', 'Rigid', 'TrussSection')
+truss.add_member('BE', 'B', 'E', 'Rigid', 'TrussSection')
 
 # Release the moments at the ends of the members to make truss members
 truss.def_releases('AC', False, False, False, False, True, True, \

--- a/PyNite/FEModel3D.py
+++ b/PyNite/FEModel3D.py
@@ -207,7 +207,7 @@ class FEModel3D():
                 count += 1
                 
         # Create a new material
-        new_material = Material(name, E, G, nu, rho, fy)
+        new_material = Material(self, name, E, G, nu, rho, fy)
         
         # Add the new material to the list
         self.materials[name] = new_material

--- a/PyNite/Material.py
+++ b/PyNite/Material.py
@@ -1,7 +1,12 @@
 class Material():
+    """
+    A class representing a material assigned to a Member3D, Plate or Quad in a finite element model.
 
-    def __init__(self, name, E, G, nu, rho, fy=None):
+    This class stores all properties related to the physical material of the element
+    """
+    def __init__(self, model, name:str, E:float, G:float, nu:float, rho:float, fy:float | None = None):
 
+        self.model = model
         self.name = name
         self.E = E
         self.G = G

--- a/PyNite/Material.py
+++ b/PyNite/Material.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 class Material():
     """
     A class representing a material assigned to a Member3D, Plate or Quad in a finite element model.
 
     This class stores all properties related to the physical material of the element
     """
-    def __init__(self, model, name:str, E:float, G:float, nu:float, rho:float, fy:float | None = None):
+    def __init__(self, model, name:str, E:float, G:float, nu:float, rho:float, fy:Optional[float] = None):
 
         self.model = model
         self.name = name

--- a/PyNite/PhysMember.py
+++ b/PyNite/PhysMember.py
@@ -12,10 +12,10 @@ class PhysMember(Member3D):
     nodes.
     """
 
-    def __init__(self, name, i_node, j_node, material_name, model, Iy, Iz, J, A, aux_node=None,
-                 tension_only=False, comp_only=False, section_name=None):
+    def __init__(self, model, name, i_node, j_node, material_name, section_name, aux_node=None,
+                 tension_only=False, comp_only=False):
         
-        super().__init__(name, i_node, j_node, material_name, model, Iy, Iz, J, A, aux_node, tension_only, comp_only, section_name)
+        super().__init__(model, name, i_node, j_node, material_name, section_name, aux_node, tension_only, comp_only)
         self.sub_members = {}
 
     def descritize(self):
@@ -77,9 +77,7 @@ class PhysMember(Member3D):
             xj = int_nodes[i+1][1]
 
             # Create a new sub-member
-            if self.section is None: section_name = None
-            else: section_name = self.section.name
-            new_sub_member = Member3D(name, i_node, j_node, self.material_name, self.model, self.Iy, self.Iz, self.J, self.A, self.auxNode, self.tension_only, self.comp_only, section_name)
+            new_sub_member = Member3D(self.model, name, i_node, j_node, self.material.name, self.section.name, self.auxNode, self.tension_only, self.comp_only)
             
             # Flag the sub-member as active
             for combo_name in self.model.load_combos.keys():

--- a/PyNite/Plastic Beam.py
+++ b/PyNite/Plastic Beam.py
@@ -15,8 +15,7 @@ fy = 50  # ksi
 plastic_beam.add_material('Stl_A992', E, G, nu, rho, fy)
 
 # Define a cross-section
-W12 = SteelSection(plastic_beam, 'W12x65', 19.1, 20, 533, 1, 15, 96.8, 'Stl_A992')
-plastic_beam.add_section('W12x65', W12)
+plastic_beam.add_steel_section('W12x65', 19.1, 20, 533, 1, 15, 96.8, 'Stl_A992')
 
 # Add nodes
 plastic_beam.add_node('N1', 0, 0, 0)
@@ -28,7 +27,7 @@ plastic_beam.def_support('N1', True, True, True, True, True, True)
 plastic_beam.def_support('N3', False, True, True, False, False, False)
 
 # Add a member
-plastic_beam.add_member('M1', 'N1', 'N3', 'Stl_A992', section_name='W12x65')
+plastic_beam.add_member('M1', 'N1', 'N3', 'Stl_A992', 'W12x65')
 
 # Add a load
 plastic_beam.add_node_load('N3', 'FY', -0.0001, 'D')

--- a/PyNite/Report_Template.html
+++ b/PyNite/Report_Template.html
@@ -67,12 +67,12 @@
                     <td>{{ member.name }}</td>
                     <td>{{ member.i_node.name }}</td>
                     <td>{{ member.j_node.name }}</td>
-                    <td>{{ "%.4g" | format(member.A) }}</td>
-                    <td>{{ "%.4g" | format(member.Iy) }}</td>
-                    <td>{{ "%.4g" | format(member.Iz) }}</td>
-                    <td>{{ "%.4g" | format(member.J) }}</td>
-                    <td>{{ "%.4g" | format(member.E) }}</td>
-                    <td>{{ "%.4g" | format(member.G) }}</td>
+                    <td>{{ "%.4g" | format(member.section.A) }}</td>
+                    <td>{{ "%.4g" | format(member.section.Iy) }}</td>
+                    <td>{{ "%.4g" | format(member.section.Iz) }}</td>
+                    <td>{{ "%.4g" | format(member.section.J) }}</td>
+                    <td>{{ "%.4g" | format(member.material.E) }}</td>
+                    <td>{{ "%.4g" | format(member.material.G) }}</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/PyNite/Section.py
+++ b/PyNite/Section.py
@@ -2,23 +2,41 @@
 import numpy as np
 
 class Section():
+    """
+    A class representing a section assigned to a 3D frame element in a finite element model.
 
-    def __init__(self, model, name, A, Iy, Iz, J, material_name):
-        
+    This class stores all properties related to the geometry of the member
+    """
+    def __init__(self, model, name:str, A:float, Iy:float, Iz:float, J:float) -> None:
+        """
+        :param model: The finite element model to which this section belongs
+        :type model: FEModel3D
+        :param name: Name of the section
+        :type name: str
+        :param A: Cross-sectional area of the section
+        :type A: float
+        :param Iy: The second moment of area the section about the Y (minor) axis
+        :type Iy: float
+        :param Iz: The second moment of area the section about the Z (major) axis
+        :type Iz: float
+        :param J: The torsion constant of the section
+        :type J: float
+        """        
         self.model = model
         self.name = name
         self.A = A
         self.Iy = Iy
         self.Iz = Iz
         self.J = J
-        self.material_name = material_name
-        self.fy = model.materials[material_name].fy
     
     def Phi(self):
         pass
 
     def G(self, fx, my, mz):
-        """Returns the gradient to the yield surface at a given point using numerical differentiation. This is a default solution. For a better solution, overwrite this method with a more precies one in the material/shape specific child class that inherits from this class.
+        """
+        Returns the gradient to the yield surface at a given point using numerical differentiation.
+        This is a default solution. For a better solution, overwrite this method with a more precies
+        one in the material/shape specific child class that inherits from this class.
         """
         
         # Small increment for numerical differentiation
@@ -49,9 +67,13 @@ class SteelSection(Section):
         self.rz = (Iz/A)**0.5
         self.Zy = Zy
         self.Zz = Zz
+
+        self.material = model.materials[material_name]
     
     def Phi(self, fx, my, mz):
-        """A method used to determine whether the cross section is elastic or plastic. Values less than 1 indicate the section is elastic.
+        """
+        A method used to determine whether the cross section is elastic or plastic. 
+        Values less than 1 indicate the section is elastic.
 
         :param fx: Axial force divided by axial strength.
         :type fx: float
@@ -64,9 +86,9 @@ class SteelSection(Section):
         """
                 
         # Plastic strengths for material nonlinearity
-        Py = self.fy*self.A
-        Mpy = self.fy*self.Zy
-        Mpz = self.fy*self.Zz
+        Py = self.material.fy*self.A
+        Mpy = self.material.fy*self.Zy
+        Mpz = self.material.fy*self.Zz
 
         # Values for p, my, and mz based on actual loads
         p = fx/Py
@@ -90,9 +112,9 @@ class SteelSection(Section):
         """
         
         # Plastic strengths for material nonlinearity
-        Py = self.fy*self.A
-        Mpy = self.fy*self.Zy
-        Mpz = self.fy*self.Zz
+        Py = self.material.fy*self.A
+        Mpy = self.material.fy*self.Zy
+        Mpz = self.material.fy*self.Zz
 
         # Partial derivatives of Phi
         dPhi_dfx = 18*fx**5*my**2/(Mpy**2*Py**6) + 2*fx/Py**2 + 7.0*fx*mz**2/(Mpz**2*Py**2)

--- a/PyNite/Section.py
+++ b/PyNite/Section.py
@@ -3,7 +3,7 @@ import numpy as np
 
 class Section():
     """
-    A class representing a section assigned to a 3D frame element in a finite element model.
+    A class representing a section assigned to a Member3D element in a finite element model.
 
     This class stores all properties related to the geometry of the member
     """

--- a/Testing/T Matrix Test.py
+++ b/Testing/T Matrix Test.py
@@ -26,15 +26,24 @@ truss.def_support('e', True, True, True, True, True, True)
 # Define properties common to all members
 E = 200000000  # kN/m^2
 G = 0.4*E
+truss.add_material('Steel',E, G, 0.3, 78.5)
+
+#Define some section properties
 J = 100
 Iy = 100
 Iz = 100
 
 # Define members
-truss.add_member('ab', 'a', 'b', E, G, Iy, Iz, J, 20*10**3/1000**2)
-truss.add_member('ac', 'a', 'c', E, G, Iy, Iz, J, 30*10**3/1000**2)
-truss.add_member('ad', 'a', 'd', E, G, Iy, Iz, J, 40*10**3/1000**2)
-truss.add_member('ae', 'a', 'e', E, G, Iy, Iz, J, 30*10**3/1000**2)
+truss.add_section('TrussSection1', 20*10**3/1000**2, Iy, Iz, J)
+truss.add_member('ab', 'a', 'b', 'Steel', 'TrussSection1')
+
+truss.add_section('TrussSection2', 30*10**3/1000**2, Iy, Iz, J)
+truss.add_member('ac', 'a', 'c', 'Steel', 'TrussSection2')
+
+truss.add_section('TrussSection3', 40*10**3/1000**2, Iy, Iz, J)
+truss.add_member('ad', 'a', 'd', 'Steel', 'TrussSection3')
+
+truss.add_member('ae', 'a', 'e', 'Steel', 'TrussSection2')
 
 # Define member end releases
 truss.def_releases('ab', False, False, False, False, True, True,

--- a/Testing/test_2D_frames.py
+++ b/Testing/test_2D_frames.py
@@ -50,11 +50,13 @@ class Test_2D_Frame(unittest.TestCase):
         Iy = 250
         Iz = 200
         A = 12
-        frame.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M2', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M3', 'N3', 'N4', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M4', 'N4', 'N5', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M5', 'N5', 'N6', 'Steel', Iy, Iz, J, A)
+        frame.add_section('FrameSection', A, Iy, Iz, J)
+
+        frame.add_member('M1', 'N1', 'N2', 'Steel', 'FrameSection')
+        frame.add_member('M2', 'N2', 'N3', 'Steel', 'FrameSection')
+        frame.add_member('M3', 'N3', 'N4', 'Steel', 'FrameSection')
+        frame.add_member('M4', 'N4', 'N5', 'Steel', 'FrameSection')
+        frame.add_member('M5', 'N5', 'N6', 'Steel', 'FrameSection')
 
         # Add nodal loads
         frame.add_node_load('N3', 'FY', -30)
@@ -99,16 +101,21 @@ class Test_2D_Frame(unittest.TestCase):
         Iz = 82.7/12**4     # ft^4
         J = 0.346/12**4     # ft^4
         A = 5.26/12**2      # in^2
+        frame.add_section('FrameSection', A, Iy, Iz, J)
+
         # Define members
-        frame.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M2', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M3', 'N4', 'N3', 'Steel', Iy, Iz, J, A)
+        frame.add_member('M1', 'N1', 'N2', 'Steel', 'FrameSection')
+        frame.add_member('M2', 'N2', 'N3', 'Steel', 'FrameSection')
+        frame.add_member('M3', 'N4', 'N3', 'Steel', 'FrameSection')
+
         # Add loads to the frame
         frame.add_member_pt_load('M2', 'Fy', -5, 7.75/2)       # 5 kips @ midspan
         frame.add_member_dist_load('M2', 'Fy', -0.024, -0.024) # W8x24 self-weight
+
         # Analyze the frame
         frame.analyze()
         calculated_RZ = frame.nodes['N1'].RZ['Combo 1']
+
         # Update the expected value to an appropriate precision
         expected_RZ = 0.00022794540510395617
         self.assertAlmostEqual(calculated_RZ/expected_RZ, 1.0, 2)
@@ -138,11 +145,14 @@ class Test_2D_Frame(unittest.TestCase):
         Iy = 250
         Iz = 200
         A = 12
-        frame.add_member('M1', 'N1', 'N2', 'Steel', Iz, Iy, J, A)
-        frame.add_member('M2', 'N2', 'N3', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M3', 'N3', 'N4', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M4', 'N4', 'N5', 'Steel', Iy, Iz, J, A)
-        frame.add_member('M5', 'N5', 'N6', 'Steel', Iz, Iy, J, A)
+        frame.add_section('FrameSection1', A, Iy, Iz, J)
+        frame.add_section('FrameSection2', A, Iz, Iy, J)
+
+        frame.add_member('M1', 'N1', 'N2', 'Steel', 'FrameSection2')
+        frame.add_member('M2', 'N2', 'N3', 'Steel', 'FrameSection1')
+        frame.add_member('M3', 'N3', 'N4', 'Steel', 'FrameSection1')
+        frame.add_member('M4', 'N4', 'N5', 'Steel', 'FrameSection1')
+        frame.add_member('M5', 'N5', 'N6', 'Steel', 'FrameSection2')
 
         # Add nodal loads
         frame.add_node_load('N3', 'FY', -30)
@@ -197,7 +207,9 @@ class Test_2D_Frame(unittest.TestCase):
         Iy = 100
         Iz = 150
         J = 250
-        SimpleBeam.add_member("M1", "N1", "N2", "Steel", Iy, Iz, J, A)
+        SimpleBeam.add_section('BeamSection', A, Iy, Iz, J)
+
+        SimpleBeam.add_member("M1", "N1", "N2", "Steel", 'BeamSection')
         # Provide simple supports
         SimpleBeam.def_support("N1", True, True, True, False, False, True)
         SimpleBeam.def_support("N2", True, True, True, False, False, False)
@@ -241,11 +253,12 @@ class Test_2D_Frame(unittest.TestCase):
         Iz = 204/12**4
         J = 0.3/12**4
         A = 7.65/12**2
+        frame.add_section('FrameSection', A, Iy, Iz, J)
 
-        frame.add_member('AC', 'A', 'C', 'Steel', Iy, Iz, J, A)
-        frame.add_member('BD', 'B', 'D', 'Steel', Iy, Iz, J, A)
-        frame.add_member('CE', 'C', 'E', 'Steel', Iy, Iz, J, A)
-        frame.add_member('ED', 'E', 'D', 'Steel', Iy, Iz, J, A)
+        frame.add_member('AC', 'A', 'C', 'Steel', 'FrameSection')
+        frame.add_member('BD', 'B', 'D', 'Steel', 'FrameSection')
+        frame.add_member('CE', 'C', 'E', 'Steel', 'FrameSection')
+        frame.add_member('ED', 'E', 'D', 'Steel', 'FrameSection')
 
         frame.def_support('A', support_DX=True, support_DY=True, support_DZ=True)
         frame.def_support('B', support_DX=True, support_DY=True, support_DZ=True)

--- a/Testing/test_AISC_PDelta_benchmarks.py
+++ b/Testing/test_AISC_PDelta_benchmarks.py
@@ -47,6 +47,7 @@ class Test_AISC_Benchmark(unittest.TestCase):
         nu = 0.3
         rho = 0.490  # kcf
         cantilever.add_material('Steel', E, G, nu, rho)
+        cantilever.add_section('BeamSection', 10/12**2, I, I, 200/12**4)
 
         # Add nodes along the length of the column to capture P-little-delta effects
         num_nodes = 6
@@ -55,7 +56,7 @@ class Test_AISC_Benchmark(unittest.TestCase):
             cantilever.add_node('N' + str(i+1), 0, i*L/(num_nodes - 1), 0)
         
         # Add the member
-        cantilever.add_member('M1', 'N1', 'N6', 'Steel', I, I, 200/12**4, 10/12**2)
+        cantilever.add_member('M1', 'N1', 'N6', 'Steel', 'BeamSection')
 
         # Add a fixed support at the base of the column
         cantilever.def_support('N1', True, True, True, True, True, True)
@@ -118,8 +119,9 @@ class Test_AISC_Benchmark(unittest.TestCase):
         Iz = 484/12**4   # ft^4
         A = 14.1/12**2   # ft^2
         J = 1.45/12**4   # ft^4
+        column.add_section('ColumnSection', A, Iy, Iz, J)
 
-        column.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
+        column.add_member('M1', 'N1', 'N2', 'Steel', 'ColumnSection')
         
         column.add_member_dist_load('M1', 'Fy', -0.200, -0.200, case='P1')
         column.add_member_dist_load('M1', 'Fy', -0.200, -0.200, case='P2')
@@ -183,8 +185,9 @@ class Test_AISC_Benchmark(unittest.TestCase):
         Iz = 484/12**4   # ft^4
         A = 14.1/12**2   # ft^2
         J = 1.45/12**4   # ft^4
+        column.add_section('ColumnSection', A, Iy, Iz, J)
 
-        column.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
+        column.add_member('M1', 'N1', 'N2', 'Steel', 'ColumnSection')
         
         column.add_node_load('N2', 'FX', 1, case='P1')
         column.add_node_load('N2', 'FX', 1, case='P2')

--- a/Testing/test_TC_analysis.py
+++ b/Testing/test_TC_analysis.py
@@ -41,9 +41,10 @@ class Test_2D_Frame(unittest.TestCase):
         Iz = 3 # in^4
         J = 0.0438 # in^4
         A = 1.94 # in^2
+        tc_model.add_section('Section', A, Iy, Iz, J)
 
-        tc_model.add_member('both-ways', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
-        tc_model.add_member('t-only top', 'N3', 'N2', 'Steel', Iy, Iz, J, A, tension_only=True)
+        tc_model.add_member('both-ways', 'N1', 'N2', 'Steel', 'Section')
+        tc_model.add_member('t-only top', 'N3', 'N2', 'Steel', 'Section', tension_only=True)
         tc_model.def_releases('t-only top', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
         tc_model.def_releases('both-ways', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
 
@@ -53,7 +54,7 @@ class Test_2D_Frame(unittest.TestCase):
         tc_model.def_support('N4', *[True]*6)
         tc_model.add_node_load('N2', 'FY', -10)
 
-        tc_model.add_member('t-only bott', 'N4', 'N2', 'Steel', Iy, Iz, J, A, tension_only=True)
+        tc_model.add_member('t-only bott', 'N4', 'N2', 'Steel', 'Section', tension_only=True)
         tc_model.def_releases('t-only bott', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
 
         tc_model.analyze()

--- a/Testing/test_end_releases.py
+++ b/Testing/test_end_releases.py
@@ -33,13 +33,14 @@ class Test_End_Release(unittest.TestCase):
         nu = 0.3
         rho = 0.490/12**3  # kci
         myModel.add_material('Steel', E, G, nu, rho)
+        myModel.add_section('ColumnSection', 10, 100, 150, 250)
 
         # Add two supported nodes and one member
         myModel.add_node('N1', 0, 0, 0)
         myModel.add_node('N2', 10*12, 0, 0)
         myModel.def_support('N1', True, True, True, True, True, True)
         myModel.def_support('N2', True, True, True, True, True, True)
-        myModel.add_member('M1', 'N1', 'N2', 'Steel', 100, 150, 250, 10)
+        myModel.add_member('M1', 'N1', 'N2', 'Steel', 'ColumnSection')
 
         # Release Rzi and Rzj on member M1
         myModel.def_releases('M1', False, False, False, False, False, True, \

--- a/Testing/test_loads.py
+++ b/Testing/test_loads.py
@@ -28,7 +28,8 @@ class TestLoads(unittest.TestCase):
         cont_beam.add_node('N2', 15, 0, 0)
         cont_beam.add_node('N3', 30, 0, 0)
         cont_beam.add_material('Steel', 29000*144, 11200*144, 0.3, 0.490)
-        cont_beam.add_member('M1', 'N1', 'N3', 'Steel', 23.3/12**4, 340/12**4, 0.569/12**4, 10/12**2)  # W14x34
+        cont_beam.add_section('Section', 10/12**2, 23.3/12**4, 340/12**4, 0.569/12**4)
+        cont_beam.add_member('M1', 'N1', 'N3', 'Steel', 'Section')  # W14x34
         cont_beam.def_support('N1', True, True, True, True, False, False)
         cont_beam.def_support('N2', False, True, True, False, False, False)
         cont_beam.def_support('N3', False, True, True, False, False, False)
@@ -61,7 +62,8 @@ class TestLoads(unittest.TestCase):
         Iz = 0.003125 # m^4
         J = 1
         A = 0.15 # m^2
-        Beam.add_member("M1", "N1", "N2", 'Mat1', Iy, Iz, J, A)
+        Beam.add_section('Section', A, Iy, Iz, J)
+        Beam.add_member("M1", "N1", "N2", 'Mat1', 'Section')
 
         # Supports
         Beam.def_support("N1", True, True, True, True, True, True)

--- a/Testing/test_member_internal_results.py
+++ b/Testing/test_member_internal_results.py
@@ -45,6 +45,7 @@ class TestMemberInternalResults(unittest.TestCase):
         Iy = 200/12**4
         Iz = 200/12**4
         A = 12/12**2
+        beam.add_section('Section', A, Iy, Iz, J)
 
         # Define a material
         E = 29000*144  # ksf
@@ -54,7 +55,7 @@ class TestMemberInternalResults(unittest.TestCase):
         beam.add_material('Steel', E, G, nu, rho)
 
         # Create the beam
-        beam.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
+        beam.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
 
         # Add a mid-span node
         beam.add_node('N3', 5, 0, 0)

--- a/Testing/test_reanalysis.py
+++ b/Testing/test_reanalysis.py
@@ -41,13 +41,14 @@ class Test_2D_Frame(unittest.TestCase):
         Iy = 30*24**3/12
         J = Iz + Iy
         A = 24*30
+        beam.add_section('Section', A, Iy, Iz, J)
 
         # Define a material
         E = 57*(4500)**0.5
         G = 0.4*E
         beam.add_material('Concrete', E, G, 0.17, 0.150/12**2)
         
-        beam.add_member('M1', 'N1', 'N3', 'Concrete', Iy, Iz, J, A)
+        beam.add_member('M1', 'N1', 'N3', 'Concrete', 'Section')
 
         # Add a member load
         w = -0.100*(10*12)
@@ -60,7 +61,7 @@ class Test_2D_Frame(unittest.TestCase):
 
         # Change the moment of inertia to account for cracking
         Iz = 0.35*Iz
-        beam.members['M1'].Iz = Iz
+        beam.members['M1'].section.Iz = Iz
 
         beam.analyze()
 

--- a/Testing/test_sloped_beam.py
+++ b/Testing/test_sloped_beam.py
@@ -46,9 +46,10 @@ class Test_2D_Frame(unittest.TestCase):
         Iy = 200/12**4
         Iz = 200/12**4
         A = 12/12**2
+        beam.add_section('Section', A, Iy, Iz, J)
 
         # Create the beam
-        beam.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
+        beam.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
         
         # Hinge the ends of the beam
         beam.def_releases('M1', False, False, False, False, True, True, False, False, False, False, True, True)

--- a/Testing/test_spring_support.py
+++ b/Testing/test_spring_support.py
@@ -52,12 +52,13 @@ class Test_Spring_Supports(unittest.TestCase):
         Iz = 128.5  # in^4 (strong axis)
         Iy = 42.6   # in^4 (weak axis)
         J = 0.769   # in^4
+        boef.add_section('Section', A, Iy, Iz, J)
 
         # Define members
         for i in range(16):
 
             # Add the members
-            boef.add_member('M' + str(i + 1), 'N' + str(i + 1), 'N' + str(i + 2), 'Steel', Iy, Iz, J, A)
+            boef.add_member('M' + str(i + 1), 'N' + str(i + 1), 'N' + str(i + 2), 'Steel', 'Section')
         
         # Add a point load at midspan
         boef.add_node_load('N9', 'FY', -40)

--- a/Testing/test_support_settlement.py
+++ b/Testing/test_support_settlement.py
@@ -46,10 +46,11 @@ class Test_Support_Settlement(unittest.TestCase):
         Iy = 1000
         Iz = 7800
         J = 8800
+        beam.add_section('Section', A, Iy, Iz, J)
 
-        beam.add_member('AB', 'A', 'B', 'Steel', Iy, Iz, J, A)
-        beam.add_member('BC', 'B', 'C', 'Steel', Iy, Iz, J, A)
-        beam.add_member('CD', 'C', 'D', 'Steel', Iy, Iz, J, A)
+        beam.add_member('AB', 'A', 'B', 'Steel', 'Section')
+        beam.add_member('BC', 'B', 'C', 'Steel', 'Section')
+        beam.add_member('CD', 'C', 'D', 'Steel', 'Section')
 
         # Provide supports
         beam.def_support('A', True, True, True, True, False, False)

--- a/Testing/test_torsion.py
+++ b/Testing/test_torsion.py
@@ -29,8 +29,10 @@ class Test_End_Release(unittest.TestCase):
         TorqueBeam.add_node('N2', 168, 0, 0)
         # Add a material
         TorqueBeam.add_material('Steel', 29000, 11400, 0.5, 490/1000/12**3)
+        #Add section
+        TorqueBeam.add_section('Section', 20, 100, 150, 250)
         # Add a beam with the following properties:
-        TorqueBeam.add_member('M1', 'N1', 'N2', 'Steel', 100, 150, 250, 20)
+        TorqueBeam.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
         # Provide fixed supports
         TorqueBeam.def_support('N1', False, True, True, True, True, True)
         TorqueBeam.def_support('N2', True, True, True, True, True, True)

--- a/Testing/test_unstable_structure.py
+++ b/Testing/test_unstable_structure.py
@@ -40,12 +40,14 @@ class Test_Unstable(unittest.TestCase):
 
         # Add columns with the following properties:
         # Iy = 100 in^4, Iz = 150 in^4, J = 250 in^4, A = 10 in^2
-        MomentFrame.add_member("M1", "N1", "N2", 'Steel', 100, 150, 250, 10)
-        MomentFrame.add_member("M2", "N4", "N3", 'Steel', 100, 150, 250, 10)
+        MomentFrame.add_section('Section', 10, 100, 150, 250)
+        MomentFrame.add_member("M1", "N1", "N2", 'Steel', 'Section')
+        MomentFrame.add_member("M2", "N4", "N3", 'Steel', 'Section')
 
         # Add a beam with the following properties:
         # Iy = 100 in^4, Iz = 250 in^4, J = 250 in^4, A = 15 in^2
-        MomentFrame.add_member("M3", "N2", "N3", 'Steel', 100, 250, 250, 15)
+        MomentFrame.add_section('Section2', 15, 100, 250, 250)
+        MomentFrame.add_member("M3", "N2", "N3", 'Steel', 'Section2')
 
         # Pin the ends of the columns
         MomentFrame.def_releases('M1', Dzi=True)

--- a/Testing/x_test_nonlinear.py
+++ b/Testing/x_test_nonlinear.py
@@ -33,8 +33,7 @@ class Test_End_Release(unittest.TestCase):
         plastic_beam.add_material('Stl_A992', E, G, nu, rho, fy)
 
         # Define a cross-section
-        W12 = SteelSection('W12x65', 19.1, 20, 533, 1, 15, 96.8, 'Stl_A992')
-        plastic_beam.add_section('W12x65', W12)
+        plastic_beam.add_steel_section('W12x65', 19.1, 20, 533, 1, 15, 96.8, 'Stl_A992')
 
         # Add nodes
         plastic_beam.add_node('N1', 0, 0, 0)
@@ -46,7 +45,7 @@ class Test_End_Release(unittest.TestCase):
         plastic_beam.def_support('N2', False, True, True, False, False, False)
         
         # Add a member
-        plastic_beam.add_member('M1', 'N1', 'N2', 'A992', section='W12x65')
+        plastic_beam.add_member('M1', 'N1', 'N2', 'A992', 'W12x65')
 
         # Add a load
         plastic_beam.add_node_load('N2', 'FY', 0.3, 'Push')

--- a/docs/source/member.rst
+++ b/docs/source/member.rst
@@ -14,11 +14,12 @@ material and section properties:
 
 .. code-block:: python
 
-    # Define a few section properties (W12x26)
+    # Define a section property (W12x26) to assign to the member
     Iy = 17.3  # (in**4) Weak axis moment of inertia
     Iz = 204   # (in**4) Strong axis moment of inertia
     J = 0.300  # (in**4) Torsional constant
-    A = 7.65   # (in**2) Cross-sectional area
+    A = 7.65   # (in**2) Cross-sectional area'
+    my_model.add_section('W12x26', A, Iy, Iz, J)
 
     # Define a new material (steel)
     E = 29000  # (ksi) Modulus of elasticity
@@ -29,8 +30,7 @@ material and section properties:
 
     # Add a member name 'M1' starting at node 'N1' and ending at node 'N2'
     # made from a previously defined material named 'Steel'
-    my_model.add_section('Section', A, Iy, Iz, J)
-    my_model.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
+    my_model.add_member('M1', 'N1', 'N2', 'Steel', 'W12x26')
 
 Local Coordinate System
 =======================

--- a/docs/source/member.rst
+++ b/docs/source/member.rst
@@ -29,7 +29,8 @@ material and section properties:
 
     # Add a member name 'M1' starting at node 'N1' and ending at node 'N2'
     # made from a previously defined material named 'Steel'
-    my_model.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A)
+    my_model.add_section('Section', A, Iy, Iz, J)
+    my_model.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
 
 Local Coordinate System
 =======================
@@ -80,9 +81,9 @@ Members can be changed to tension or compression only by passing ``tension_only=
 ``comp_only=True`` to the ``FEModel3D.add_member()`` method. Here's an example:
 
 .. code-block:: python
-
-    my_model.add_member('M1', 'N1', 'N2', 'Steel', Iy, Iz, J, A, tension-only=True)
-    my_model.add_member('M2', 'N1', 'N2', 'Steel', Iy, Iz, J, A, comp-only=True)
+    my_model.add_section('Section', A, Iy, Iz, J)
+    my_model.add_member('M1', 'N1', 'N2', 'Steel', 'Section', tension-only=True)
+    my_model.add_member('M2', 'N1', 'N2', 'Steel', 'Section', comp-only=True)
 
 Tension-only and compression-only analysis is an iterative process. When using these types of
 members be sure to perform a non-linear analysis. Do not use the ``FEModel3D.analyze_linear()``

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -29,9 +29,12 @@ Here's a simple example of how to analyze a simple beam. Many more examples are 
     rho = 2.836e-4  # Density (kci)
     beam.add_material('Steel', E, G, nu, rho)
 
-    # Add a beam with the following properties:
+    # Add a section with the following properties:
     # Iy = 100 in^4, Iz = 150 in^4, J = 250 in^4, A = 20 in^2
-    beam.add_member('M1', 'N1', 'N2', 'Steel', 100, 150, 250, 20)
+    my_model.add_section('MySection', 20, 100, 150, 250)
+
+    #Add a member
+    beam.add_member('M1', 'N1', 'N2', 'Steel', 'MySection')
 
     # Provide simple supports
     beam.def_support('N1', True, True, True, False, False, False)


### PR DESCRIPTION
Following on from the discussion here #202 and working towards a v1.0.0 release, this pull request enforces the use of section properties when defining Member3D elements. This simplifies the processes of creating Member3D objects, by effectively grouping parameters to be passed to the `__init__ ` method. It also ensures consistency in the way that section properties are stored within the FEA model, which is critical as the package matures.

This pull request also alters the Member3D class logic slightly, so that the section and material properties are not extracted in the Member3D `__init__ ` method, but instead accessed directly from the appropriate section or material instances during analysis. This  enables simple alteration of section or material properties between analysis runs, with the confidence that any changes are propogated through to all members referencin gthe given section or material.

The same approach could be taken for Quad & Plate elements, but can be covered in a different pull request.

These changes will break most user's code.