### PR TITLE
Fix several bugs in Examples

### DIFF
--- a/Examples/Braced Frame - Tension Only.py
+++ b/Examples/Braced Frame - Tension Only.py
@@ -76,18 +76,18 @@ braced_frame.def_support('N3', support_DZ=True)
 # to the full member length. Note also that the direction uses lowercase
 # notations to indicate member local coordinate systems. Brace loads have been
 # neglected.
-braced_frame.add_member_dist_load('Beam', Direction='Fy', w1=-0.024/12,
+braced_frame.add_member_dist_load('Beam', direction='Fy', w1=-0.024/12,
                               w2=-0.024/12, x1=0, x2=15*12, case='D')
-braced_frame.add_member_dist_load('Col1', Direction='Fx', w1=-0.033/12,
+braced_frame.add_member_dist_load('Col1', direction='Fx', w1=-0.033/12,
                               w2=-0.033/12, x1=0, x2=12*12, case='D')
-braced_frame.add_member_dist_load('Col2', Direction='Fx', w1=-0.033/12,
+braced_frame.add_member_dist_load('Col2', direction='Fx', w1=-0.033/12,
                               w2=-0.033/12, x1=0, x2=12*12, case='D')
 
 # Add nodal wind loads of 25 kips to each side of the frame. Note that the
 # direction uses uppercase notation to indicate model global coordinate
 # system.
-braced_frame.add_node_load('N2', Direction='FX', P=25, case='W')
-braced_frame.add_node_load('N3', Direction='FX', P=25, case='W')
+braced_frame.add_node_load('N2', direction='FX', P=25, case='W')
+braced_frame.add_node_load('N3', direction='FX', P=25, case='W')
 
 # Create load combinations
 # Note that the load combination '1.4D' has no lateral load, but does have

--- a/Examples/Circular Bin with Conical Hopper.py
+++ b/Examples/Circular Bin with Conical Hopper.py
@@ -69,5 +69,11 @@ model.add_load_combo('1.4F', {'Hydrostatic': 1.4})
 model.analyze()
 
 # Render the model. Labels and loads will be turned off to speed up interaction.
-from PyNite.Visualization import Renderer, render_model
-render_model(model, 0.1, render_loads=True, color_map='dz', combo_name='1.4F', labels=False)
+from PyNite.Visualization import Renderer
+rndr = Renderer(model)
+rndr.annotation_size = 0.1
+rndr.render_loads = False
+rndr.color_map = 'dz'
+rndr.combo_name = '1.4F'
+rndr.labels = False
+rndr.render_model()

--- a/Examples/Moment Frame - Lateral Load.py
+++ b/Examples/Moment Frame - Lateral Load.py
@@ -48,13 +48,13 @@ MomentFrame.def_support('N4', support_DX=True, support_DY=True, support_DZ=True,
 # Add self weight dead loads to the frame
 # Note that we could leave 'x1' and 'x2' undefined below and it would default to the full member length
 # Note also that the direction uses lowercase notations to indicate member local coordinate systems
-MomentFrame.add_member_dist_load('Beam', Direction='Fy', w1=-0.024/12, w2=-0.024/12, x1=0, x2=15*12, case='D')
-MomentFrame.add_member_dist_load('Col1', Direction='Fx', w1=-0.033/12, w2=-0.033/12, x1=0, x2=12*12, case='D')
-MomentFrame.add_member_dist_load('Col2', Direction='Fx', w1=-0.033/12, w2=-0.033/12, x1=0, x2=12*12, case='D')
+MomentFrame.add_member_dist_load('Beam', direction='Fy', w1=-0.024/12, w2=-0.024/12, x1=0, x2=15*12, case='D')
+MomentFrame.add_member_dist_load('Col1', direction='Fx', w1=-0.033/12, w2=-0.033/12, x1=0, x2=12*12, case='D')
+MomentFrame.add_member_dist_load('Col2', direction='Fx', w1=-0.033/12, w2=-0.033/12, x1=0, x2=12*12, case='D')
 
 # Add a nodal wind load of 10 kips at the left side of the frame
 # Note that the direction uses uppercase notation to indicate model global coordinate system
-MomentFrame.add_node_load('N2', Direction='FX', P=10, case='W')
+MomentFrame.add_node_load('N2', direction='FX', P=10, case='W')
 
 # Create two load combinations
 MomentFrame.add_load_combo('1.2D+1.0W', factors={'D':1.2, 'W':1.0})

--- a/Examples/Moment Frame - Lateral Load.py
+++ b/Examples/Moment Frame - Lateral Load.py
@@ -71,8 +71,13 @@ MomentFrame.analyze_PDelta(log=True)
 # MomentFrame.analyze_linear(log=True)
 
 # Display the deformed shape of the structure magnified 50 times with the text height 5 model units (inches) high
-from PyNite import Visualization
-Visualization.render_model(MomentFrame, annotation_size=5, deformed_shape=True, deformed_scale=50, combo_name='1.2D+1.0W')
+from PyNite.Visualization import Renderer
+rndr = Renderer(MomentFrame)
+rndr.annotation_size = 5
+rndr.deformed_shape = True
+rndr.deformed_scale = 50
+rndr.combo_name = '1.2D+1.0W'
+rndr.render_model(MomentFrame)
 
 # Plot the moment diagram for the beam
 MomentFrame.members['Beam'].plot_moment('Mz', combo_name='1.2D+1.0W')

--- a/Examples/Rectangular Tank Wall - Hydrostatic Loads.py
+++ b/Examples/Rectangular Tank Wall - Hydrostatic Loads.py
@@ -74,7 +74,7 @@ renderer.deformed_shape = True
 renderer.deformed_scale = 1000
 renderer.color_map = 'Qy'
 renderer.combo_name = '1.4F'
-renderer.labels = True
+renderer.show_labels = True
 renderer.scalar_bar = True
 renderer.scalar_bar_text_size = 12
 renderer.render_model()
@@ -89,10 +89,10 @@ Mx = -0.0131*qo*a**2
 My = -0.0242*qo*a**2
 
 # Pynite solution
-Qx_pn = model.Quads['Q176'].shear(-1, 0, True, '1.4F')[0, 0]
-Qy_pn = model.Meshes['MSH1'].max_shear('Qy', '1.4F')
-Mx_pn = model.Quads['Q176'].moment(-1, 0, True, '1.4F')[0, 0]
-My_pn = model.Meshes['MSH1'].min_moment('My', '1.4F')
+Qx_pn = model.quads['Q176'].shear(-1, 0, True, '1.4F')[0, 0]
+Qy_pn = model.meshes['MSH1'].max_shear('Qy', '1.4F')
+Mx_pn = model.quads['Q176'].moment(-1, 0, True, '1.4F')[0, 0]
+My_pn = model.meshes['MSH1'].min_moment('My', '1.4F')
 
 # Comparison of solutions
 print('Max Moment at Side Mid-Height of Wall, Mx | Pynite: ', Mx_pn, '| Timoshenko: ', Mx)

--- a/Examples/Space Frame - Nodal Loads 2.py
+++ b/Examples/Space Frame - Nodal Loads 2.py
@@ -5,7 +5,7 @@
 
 # Import 'FEModel3D' and 'Visualization' from 'PyNite'
 from PyNite import FEModel3D
-from PyNite import Visualization
+from PyNite.Visualization import Renderer
 
 # Create a new model
 frame = FEModel3D()
@@ -49,5 +49,11 @@ frame.analyze()
 print('Calculated results: ', frame.nodes['N2'].DY, frame.nodes['N3'].DZ)
 print('Expected results: ', -0.063, 1.825)
 
-# Render the model for viewing
-Visualization.render_model(frame, annotation_size=5, deformed_shape=True, deformed_scale=40, render_loads=True)
+# Render the deformed shape
+rndr = Renderer(frame)
+rndr.annotation_size = 5
+rndr.render_loads = True
+rndr.deformed_shape = True
+rndr.deformed_scale = 40
+rndr.render_loads = True
+rndr.render_model()


### PR DESCRIPTION
fix #228 

Thank you for providing the program, but I have found some bugs. I have submitted a Pull Request for your consideration. Here are detailed fixes.

- Fix method keyword args
  - Fix `add_member_dist_load` and `add_node_load` method in `Braced Frame - Tension Only.py` and `Moment Frame - Lateral Load.py`.
  - Change kwargs from `Direction` to `direction`.
- Fix render code in examples
  - Due to commit 668e69279cd985a704b91c4e0303e3865039d304 , `render_model` is deprecated. So change it to `Rendered` class.
- Fix FEModel3D and Renderer attr in Examples
  - `FEModel3D` does not have attr like `Quads` or `Meshes`, change it to `quads` and `meshes`, respectively.
  - `Renderer` does not have attr `labels`, change it to `show_labels`.

Following the completion of the aforementioned fixes, all scripts in the `Examples` folder can now run smoothly on my local machine.