### PR TITLE
Docs/fix typo

### DIFF
--- a/Pynite/Member3D.py
+++ b/Pynite/Member3D.py
@@ -1741,7 +1741,7 @@ class Member3D():
                 return self._extract_vector_results(self.SegmentsZ, x_array, 'axial_deflection', P_delta)
             
             else:
-                raise ValueError(f"Direction must be 'My' or 'Mz'. {Direction} was given.")
+                raise ValueError(f"Direction must be 'dx', 'dy' or 'dz'. {Direction} was given.")
 
     def rel_deflection(self, Direction, x, combo_name='Combo 1'):
         """

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -56,8 +56,8 @@ Here's a simple example of how to analyze a simple beam. Many more examples are 
     beam.members['M1'].plot_deflection('dy')
 
     # Print reactions at each end of the beam
-    print('Left Support Reaction:', beam.nodes['N1'].RxnFY, 'kip')
-    print('Right Support Reacton:', beam.nodes['N2'].RxnFY, 'kip')
+    print(f"Left Support Reaction: { {k: float(v) for k, v in beam.nodes['N1'].RxnFY.items()} }")
+    print(f"Right Support Reaction: { {k: float(v) for k, v in beam.nodes['N2'].RxnFY.items()} }")
 
     # Render the deformed shape of the beam magnified 100 times, with a text
     # height of 5 inches

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -31,7 +31,7 @@ Here's a simple example of how to analyze a simple beam. Many more examples are 
 
     # Add a section with the following properties:
     # Iy = 100 in^4, Iz = 150 in^4, J = 250 in^4, A = 20 in^2
-    my_model.add_section('MySection', 20, 100, 150, 250)
+    beam.add_section('MySection', 20, 100, 150, 250)
 
     #Add a member
     beam.add_member('M1', 'N1', 'N2', 'Steel', 'MySection')
@@ -45,7 +45,7 @@ Here's a simple example of how to analyze a simple beam. Many more examples are 
 
     # Alternatively the following line would do apply the load to the full
     # length of the member as well
-    # beam.add_member_dist_load('M1', 'Fy', 200/1000/12, 200/1000/12)
+    # beam.add_member_dist_load('M1', 'Fy', -200/1000/12, -200/1000/12)
 
     # Analyze the beam
     beam.analyze()


### PR DESCRIPTION
Fix typos in quickstart.rst and suggestion for printing reactions as Python floats as opposed to np.float64 for visual cleanliness.