### PR TITLE
Added type hints throughout

### DIFF
--- a/Pynite/BeamSegY.py
+++ b/Pynite/BeamSegY.py
@@ -1,11 +1,12 @@
 from Pynite.BeamSegZ import BeamSegZ
 
+
 # %%
 class BeamSegY(BeamSegZ):
 
 #%% 
     # Returns the moment at a location on the segment
-    def moment(self, x, P_delta=False):
+    def moment(self, x: float, P_delta: bool = False) -> float:
         '''
         Returns the moment at a location on the segment.
 
@@ -32,7 +33,7 @@ class BeamSegY(BeamSegZ):
         
         return M
 
-    def slope(self, x, P_delta=False):
+    def slope(self, x: float, P_delta: bool = False) -> float:
         """Returns the slope of the elastic curve at any point `x` along the segment.
 
         :param x: Location (relative to start of segment) where slope is to be calculated.
@@ -62,7 +63,7 @@ class BeamSegY(BeamSegZ):
 
 #%%
     # Returns the deflection at a location on the segment
-    def deflection(self, x, P_delta=False):
+    def deflection(self, x: float, P_delta: bool = False) -> float:
         
         V1 = self.V1
         M1 = self.M1
@@ -109,7 +110,7 @@ class BeamSegY(BeamSegZ):
     
 #%%
     # Returns the maximum moment in the segment
-    def max_moment(self, P_delta=False):
+    def max_moment(self, P_delta: bool = False) -> float:
         
         w1 = self.w1
         w2 = self.w2
@@ -155,7 +156,7 @@ class BeamSegY(BeamSegZ):
 
 #%%
     # Returns the minimum moment in the segment
-    def min_moment(self, P_delta=False):
+    def min_moment(self, P_delta: bool = False) -> float:
         
         w1 = self.w1
         w2 = self.w2
@@ -198,4 +199,3 @@ class BeamSegY(BeamSegZ):
     
         # Return the minimum moment
         return min(M1, M2, M3, M4)
-    

--- a/Pynite/BeamSegZ.py
+++ b/Pynite/BeamSegZ.py
@@ -4,8 +4,14 @@ Created on Mon Nov  6 20:52:31 2017
 
 @author: D. Craig Brinck, SE
 """
+from __future__ import annotations # Allows more recent type hints features
+from typing import TYPE_CHECKING
+
 from numpy import full, array
 
+if TYPE_CHECKING:
+    from typing import Any, List
+    from numpy.typing import NDArray
 # %%
 # A mathematically continuous beam segment
 class BeamSegZ():
@@ -60,29 +66,29 @@ class BeamSegZ():
     
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Constructor
         """
         
-        self.x1 = None # Start location of beam segment (relative to start of beam)
-        self.x2 = None # End location of beam segment (relative to start of beam)
-        self.w1 = None # Linear distributed transverse load at start of segment
-        self.w2 = None # Linear distributed transverse load at end of segment
-        self.p1 = None # Linear distributed axial load at start of segment
-        self.p2 = None # Linear distributed axial load at end of segment
-        self.V1 = None # Internal shear force at start of segment
-        self.M1 = None # Internal moment at start of segment
-        self.P1 = None # Internal axial force at start of segment
-        self.T1 = None # Torsional moment at start of segment
-        self.theta1 = None # Slope at start of beam segment
-        self.delta1 = None # Displacement at start of beam segment
-        self.delta_x1 = None # Axial displacement at start of beam segment
-        self.EI = None # Flexural stiffness of the beam segment
-        self.EA = None # Axial stiffness of the beam segment
+        self.x1: float | None = None # Start location of beam segment (relative to start of beam)
+        self.x2: float | None = None # End location of beam segment (relative to start of beam)
+        self.w1: float | None = None # Linear distributed transverse load at start of segment
+        self.w2: float | None = None # Linear distributed transverse load at end of segment
+        self.p1: float | None = None # Linear distributed axial load at start of segment
+        self.p2: float | None = None # Linear distributed axial load at end of segment
+        self.V1: float | None = None # Internal shear force at start of segment
+        self.M1: float | None = None # Internal moment at start of segment
+        self.P1: float | None = None # Internal axial force at start of segment
+        self.T1: float | None = None # Torsional moment at start of segment
+        self.theta1: float | None = None # Slope at start of beam segment
+        self.delta1: float | None = None # Displacement at start of beam segment
+        self.delta_x1: float | None = None # Axial displacement at start of beam segment
+        self.EI: float | None = None # Flexural stiffness of the beam segment
+        self.EA: float | None = None # Axial stiffness of the beam segment
 
     # Returns the length of the segment
-    def Length(self):
+    def Length(self) -> float:
         """
         Returns the length of the segment
         """
@@ -90,7 +96,7 @@ class BeamSegZ():
         return self.x2 - self.x1
 
     # Returns the shear force at a location 'x' on the segment
-    def Shear(self, x):
+    def Shear(self, x: float) -> float:
         
         V1 = self.V1
         w1 = self.w1
@@ -100,7 +106,7 @@ class BeamSegZ():
         return V1 + w1*x + x**2*(-w1 + w2)/(2*L)
 
     # Returns the moment at a location on the segment
-    def moment(self, x, P_delta=False):
+    def moment(self, x: float, P_delta: bool = False) -> float:
 
         V1 = self.V1
         M1 = self.M1
@@ -121,7 +127,7 @@ class BeamSegZ():
         return M
 
     # Returns the axial force at a location on the segment
-    def axial(self, x):
+    def axial(self, x: float) -> float:
         
         P1 = self.P1
         p1 = self.p1
@@ -130,7 +136,7 @@ class BeamSegZ():
         
         return P1 + (p2 - p1)/(2*L)*x**2 + p1*x
 
-    def Torsion(self, x = 0):
+    def Torsion(self, x: float | List[float] = 0) -> float | None | NDArray[Any]:
         """
         Returns the torsional moment in the segment.
         """
@@ -145,7 +151,7 @@ class BeamSegZ():
         else:
             return full(len(x), self.T1)
     
-    def slope(self, x, P_delta=False):
+    def slope(self, x: float, P_delta: bool = False) -> float:
         """Returns the slope of the elastic curve at any point `x` along the segment.
 
         :param x: Location (relative to start of segment) where slope is to be calculated.
@@ -180,7 +186,7 @@ class BeamSegZ():
         return theta_x
 
     # Returns the deflection at a location on the segment
-    def deflection(self, x, P_delta=False):
+    def deflection(self, x: float, P_delta: bool = False) -> float:
         
         V1 = self.V1
         M1 = self.M1
@@ -227,7 +233,7 @@ class BeamSegZ():
             # return delta1 + theta1*x - M1*x**2/(2*EI) + V1*x**3/(6*EI) + w1*x**4/(24*EI) + x**5*(-w1 + w2)/(120*EI*L)
             return delta_1 + theta_1*x + V1*x**3/(6*EI) + w1*x**4/(24*EI) + x**2*(-M1)/(2*EI) + x**5*(-w1 + w2)/(120*EI*L)
 
-    def AxialDeflection(self, x):
+    def AxialDeflection(self, x: float) -> float:
 
         delta_x1 = self.delta_x1
         P1 = self.P1
@@ -239,7 +245,7 @@ class BeamSegZ():
         return delta_x1 - 1/EA*(P1*x + p1*x**2/2 + (p2 - p1)*x**3/(6*L))
 
     # Returns the maximum shear in the segment
-    def max_shear(self):
+    def max_shear(self) -> float:
         
         w1 = self.w1
         w2 = self.w2
@@ -266,7 +272,7 @@ class BeamSegZ():
         return max(V1, V2, V3)
 
     # Returns the minimum shear in the segment
-    def min_shear(self):
+    def min_shear(self) -> float:
         
         w1 = self.w1
         w2 = self.w2
@@ -293,7 +299,7 @@ class BeamSegZ():
         return min(V1, V2, V3)
     
     # Returns the maximum moment in the segment
-    def max_moment(self, P_delta=False):
+    def max_moment(self, P_delta: bool = False) -> float:
         
         w1 = self.w1
         w2 = self.w2
@@ -338,7 +344,7 @@ class BeamSegZ():
         return max(M1, M2, M3, M4)
 
     # Returns the minimum moment in the segment
-    def min_moment(self, P_delta=False):
+    def min_moment(self, P_delta: bool = False) -> float:
         
         w1 = self.w1
         w2 = self.w2
@@ -383,7 +389,7 @@ class BeamSegZ():
         return min(M1, M2, M3, M4)
 
     # Returns the maximum axial force in the segment
-    def max_axial(self):
+    def max_axial(self) -> float:
         
         p1 = self.p1
         p2 = self.p2
@@ -410,7 +416,7 @@ class BeamSegZ():
         return max(P1, P2, P3)
 
     # Returns the minimum axial force in the segment
-    def min_axial(self):
+    def min_axial(self) -> float:
         
         p1 = self.p1
         p2 = self. p2
@@ -436,7 +442,7 @@ class BeamSegZ():
         # Return the minimum axial force
         return min(P1, P2, P3)
 
-    def MaxTorsion(self):
+    def MaxTorsion(self) -> float:
         """
         Returns the maximum torsional moment in the segment.
         """
@@ -446,7 +452,7 @@ class BeamSegZ():
         # This can be updated in the future for distributed torsional forces
         return self.T1
 
-    def MinTorsion(self):
+    def MinTorsion(self) -> float:
         """
         Returns the minimum torsional moment in the segment.
         """

--- a/Pynite/FEModel3D.py
+++ b/Pynite/FEModel3D.py
@@ -1,10 +1,10 @@
 # %%
 #futures import required to use bar operators for optional type annotations
-from __future__ import annotations
-
+from __future__ import annotations # Allows more recent type hints features
 from os import rename
 import warnings
 from math import isclose
+from typing import TYPE_CHECKING
 
 from numpy import array, zeros, matmul, divide, subtract, atleast_2d, all
 from numpy.linalg import solve
@@ -21,6 +21,10 @@ from Pynite.LoadCombo import LoadCombo
 from Pynite.Mesh import Mesh, RectangleMesh, AnnulusMesh, FrustrumMesh, CylinderMesh
 from Pynite import Analysis
 
+if TYPE_CHECKING:
+    from typing import Dict, List
+    from numpy import float64
+    from numpy.typing import NDArray
 
 # %%
 class FEModel3D():
@@ -28,7 +32,7 @@ class FEModel3D():
        and retrieve results from a finite element model.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Creates a new 3D finite element model.
         """
         
@@ -36,36 +40,26 @@ class FEModel3D():
         # the data types they store, and then those types will be removed. This will give us the
         # ability to get type-based hints when using the dictionaries.
 
-        self.nodes = {str:Node3D}          # A dictionary of the model's nodes
-        self.nodes.pop(str)
-        self.materials = {str:Material}    # A dictionary of the model's materials
-        self.materials.pop(str)
-        self.sections = {str:Section}      # A dictonary of the model's cross-sections
-        self.sections.pop(str)
-        self.springs = {str:Spring3D}      # A dictionary of the model's springs
-        self.springs.pop(str)
-        self.members = {str:PhysMember}    # A dictionary of the model's physical members
-        self.members.pop(str)
-        self.quads = {str:Quad3D}          # A dictionary of the model's quadiralterals
-        self.quads.pop(str)
-        self.plates = {str:Plate3D}        # A dictionary of the model's rectangular plates
-        self.plates.pop(str)
-        self.meshes = {str:Mesh}           # A dictionary of the model's meshes
-        self.meshes.pop(str)         
-        self.load_combos = {str:LoadCombo}  # A dictionary of the model's load combinations
-        self.load_combos.pop(str)
-        self._D = {str:[]}                 # A dictionary of the model's nodal displacements by load combination
-        self._D.pop(str)
+        self.nodes: Dict[str, Node3D] = {}             # A dictionary of the model's nodes
+        self.materials: Dict[str, Material] = {}       # A dictionary of the model's materials
+        self.sections: Dict[str, Section] = {}         # A dictonary of the model's cross-sections
+        self.springs: Dict[str, Spring3D] = {}         # A dictionary of the model's springs
+        self.members: Dict[str, PhysMember] = {}       # A dictionary of the model's physical members
+        self.quads: Dict[str, Quad3D] = {}             # A dictionary of the model's quadiralterals
+        self.plates: Dict[str, Plate3D] = {}           # A dictionary of the model's rectangular plates
+        self.meshes: Dict[str, Mesh] = {}              # A dictionary of the model's meshes
+        self.load_combos: Dict[str, LoadCombo] = {}    # A dictionary of the model's load combinations
+        self._D: Dict[str, NDArray[float64]] = {}      # A dictionary of the model's nodal displacements by load combination
         
-        self.solution = None  # Indicates the solution type for the latest run of the model
+        self.solution: str | None = None  # Indicates the solution type for the latest run of the model
 
     @property
-    def load_cases(self):
+    def load_cases(self) -> List[str]:
         """Returns a list of all the load cases in the model (in alphabetical order).
         """
         
         # Create an empty list of load cases
-        cases = []
+        cases: List[str] = []
 
         # Step through each node
         for node in self.nodes.values():
@@ -1820,14 +1814,14 @@ class FEModel3D():
         # Return the global plastic reduction matrix
         return Km 
 
-    def FER(self, combo_name='Combo 1'):
+    def FER(self, combo_name='Combo 1') -> NDArray[float64]:
         """Assembles and returns the global fixed end reaction vector for any given load combo.
 
         :param combo_name: The name of the load combination to get the fixed end reaction vector
                            for. Defaults to 'Combo 1'.
         :type combo_name: str, optional
         :return: The fixed end reaction vector
-        :rtype: array
+        :rtype: NDArray[float64]
         """        
         
         # Initialize a zero vector to hold all the terms
@@ -1920,14 +1914,14 @@ class FEModel3D():
         # Return the global fixed end reaction vector
         return FER
     
-    def P(self, combo_name='Combo 1'):
+    def P(self, combo_name='Combo 1') -> NDArray[float64]:
         """Assembles and returns the global nodal force vector.
 
         :param combo_name: The name of the load combination to get the force vector for. Defaults
                            to 'Combo 1'.
         :type combo_name: str, optional
         :return: The global nodal force vector.
-        :rtype: array
+        :rtype: NDArray[float64]
         """
             
         # Initialize a zero vector to hold all the terms
@@ -1966,14 +1960,14 @@ class FEModel3D():
         # Return the global nodal force vector
         return P
 
-    def D(self, combo_name='Combo 1'):
+    def D(self, combo_name='Combo 1') -> NDArray[float64]:
         """Returns the global displacement vector for the model.
 
         :param combo_name: The name of the load combination to get the results for. Defaults to
                            'Combo 1'.
         :type combo_name: str, optional
         :return: The global displacement vector for the model
-        :rtype: array
+        :rtype: NDArray[float64]
         """
  
         # Return the global displacement vector
@@ -2464,4 +2458,4 @@ class FEModel3D():
                 orphans.append(node.name)
         
         return orphans
-      
+

--- a/Pynite/FixedEndReactions.py
+++ b/Pynite/FixedEndReactions.py
@@ -5,22 +5,29 @@ Created on Fri Nov  3 20:58:03 2017
 @author: D. Craig Brinck, SE
 """
 # %%
+from __future__ import annotations # Allows more recent type hints features
+from typing import TYPE_CHECKING
+
 from numpy import zeros
 
+if TYPE_CHECKING:
+    from typing import Literal
+    from numpy import float64
+    from numpy.typing import NDArray
 # %%
-def FER_PtLoad(P, x, L, Direction):
+def FER_PtLoad(P: float, x: float, L: float, Direction: Literal["Fy", "Fz"]) -> NDArray[float64]:
     """
     Returns the fixed end reaction vector for a point load
     
     Parameters:
     -----------
-    P : number
+    P : float
         The magnitude of the point load
-    x : number
+    x : float
         The location of the point load relative to the start of the member
-    L : number
+    L : float
         The length of the member
-    Direction : string
+    Direction : Literal["Fy", "Fz"]
         The direction of the point load. Must be one of the following:
             "Fy" = Force on the member's local y-axis
             "Fz" = Force on the member's local z-axis
@@ -46,17 +53,19 @@ def FER_PtLoad(P, x, L, Direction):
     return FER
     
 # %%
-def FER_Moment(M, x, L, Direction):
+def FER_Moment(M: float, x: float, L: float, Direction: Literal["My", "Mz"]) -> NDArray[float64]:
     """
     Returns the fixed end reaction vector for a concentrated moment
     
     Parameters
     ----------
-    M : number
+    M : float
         The magnitude of the moment
-    x : number
+    x : float
         The location of the moment relative to the start of the member
-    Direction : string
+    L : float
+        The length of the member
+    Direction : Literal["My", "Mz"]
         The direction of the moment. Must be one of the following:
             "My" = Moment applied about the local y-axis
             "Mz" = Moment applied about the local z-axis
@@ -83,7 +92,27 @@ def FER_Moment(M, x, L, Direction):
     
 # %%
 # Returns the fixed end reaction vector for a linear distributed load
-def FER_LinLoad(w1, w2, x1, x2, L, Direction):
+def FER_LinLoad(w1: float, w2: float, x1: float, x2: float, L: float, Direction: Literal["Fy", "Fz"]) -> NDArray[float64]:
+    """
+    Returns the fixed end reaction vector for a linear distributed load
+    
+    Parameters
+    ----------
+    w1 : float
+        The load magnitude at the start location
+    w2 : float
+        The load magnitude at the end location
+    x1 : float
+        The start location of the distributed load
+    x2 : float
+        The end location of the distributed load
+    L : float
+        The length of the member
+    Direction : Literal["Fy", "Fz"]
+        The direction of the distributed load. Must be one of the following:
+            "Fy" = Force on the member's local y-axis
+            "Fz" = Force on the member's local z-axis
+    """
         
     # Create the fixed end reaction vector
     FER = zeros((12, 1))
@@ -104,7 +133,19 @@ def FER_LinLoad(w1, w2, x1, x2, L, Direction):
 
 # %%
 # Returns the fixed end reaction vector for an axial point load
-def FER_AxialPtLoad(P, x, L):
+def FER_AxialPtLoad(P: float, x: float, L: float) -> NDArray[float64]:
+    """
+    Returns the fixed end reaction vector for an axial point load
+    
+    Parameters
+    ----------
+    P : float
+        The magnitude of the axial point load
+    x : float
+        The location of the axial point load relative to the start of the member
+    L : float
+        The length of the member
+    """
     
     # Create the fixed end reaction vector
     FER = zeros((12, 1))
@@ -117,7 +158,23 @@ def FER_AxialPtLoad(P, x, L):
 
 # %%
 # Returns the fixed end reaction vector for a distributed axial load
-def FER_AxialLinLoad(p1, p2, x1, x2, L):
+def FER_AxialLinLoad(p1: float, p2: float, x1: float, x2: float, L: float) -> NDArray[float64]:
+    """
+    Returns the fixed end reaction vector for a distributed axial load
+    
+    Parameters
+    ----------
+    p1 : float
+        The axial load magnitude at the start location
+    p2 : float
+        The axial load magnitude at the end location
+    x1 : float
+        The start location of the distributed axial load
+    x2 : float
+        The end location of the distributed axial load
+    L : float
+        The length of the member
+    """
     
     # Create the fixed end reaction vector
     FER = zeros((12, 1))
@@ -128,16 +185,18 @@ def FER_AxialLinLoad(p1, p2, x1, x2, L):
     
     return FER
  
-def FER_Torque(T, x, L):
+def FER_Torque(T: float, x: float, L: float) -> NDArray[float64]:
     """
     Returns the fixed end reaction vector for a concentrated torque
 
     Parameters
     ----------
-    T : number
+    T : float
         The magnitude of the torque
-    x : number
+    x : float
         The location of the torque relative to the start of the member
+    L : float
+        The length of the member
     """
 
     # Create the fixed end reaction vector

--- a/Pynite/LoadCombo.py
+++ b/Pynite/LoadCombo.py
@@ -1,8 +1,11 @@
+from __future__ import annotations # Allows more recent type hints features
+from typing import Dict, List
+
 class LoadCombo():
     """A class that stores all the information necessary to define a load combination.
     """
 
-    def __init__(self, name, combo_tags=None, factors={}):
+    def __init__(self, name: str, combo_tags: List[str] | None = None, factors: Dict[str, float] = {}) -> None:
         """Initializes a new load combination.
 
         :param name: A unique name for the load combination.
@@ -13,20 +16,28 @@ class LoadCombo():
         :type factors: dict, optional
         """
         
-        self.name = name             # A unique user-defined name for the load combination
-        self.combo_tags = combo_tags   # Used to categorize the load combination (e.g. strength or serviceability)
-        self.factors = factors       # A dictionary containing each load case name and associated load factor
+        self.name: str = name             # A unique user-defined name for the load combination
+        self.combo_tags: List[str] | None = combo_tags   # Used to categorize the load combination (e.g. strength or serviceability)
+        self.factors: Dict[str, float] = factors       # A dictionary containing each load case name and associated load factor
     
-    def AddLoadCase(self, case_name, factor):
+    def AddLoadCase(self, case_name: str, factor: float) -> None:
         '''
         Adds a load case with its associated load factor
+
+        :param case_name: The name of the load case
+        :type case_name: str
+        :param factor: The load factor to apply to the load case
+        :type factor: float
         '''
 
         self.factors[case_name] = factor
     
-    def DeleteLoadCase(self, case_name):
+    def DeleteLoadCase(self, case_name: str) -> None:
         '''
         Deletes a load case with its associated load factor
+
+        :param case_name: The name of the load case to delete
+        :type case_name: str
         '''
 
         del self.factors[case_name]

--- a/Pynite/Material.py
+++ b/Pynite/Material.py
@@ -1,4 +1,8 @@
-from typing import Optional
+from __future__ import annotations # Allows more recent type hints features
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from Pynite.FEModel3D import FEModel3D
 
 class Material():
     """
@@ -6,12 +10,29 @@ class Material():
 
     This class stores all properties related to the physical material of the element
     """
-    def __init__(self, model, name:str, E:float, G:float, nu:float, rho:float, fy:Optional[float] = None):
+    def __init__(self, model: FEModel3D, name: str, E: float, G: float, nu: float, rho: float, fy: float | None = None) -> None:
+        """Initialize a material object.
 
-        self.model = model
-        self.name = name
-        self.E = E
-        self.G = G
-        self.nu = nu
-        self.rho = rho
-        self.fy = fy
+        :param model: The finite element model this material belongs to
+        :type model: FEModel3D
+        :param name: A unique name for the material
+        :type name: str
+        :param E: Modulus of elasticity
+        :type E: float
+        :param G: Shear modulus
+        :type G: float
+        :param nu: Poisson's ratio
+        :type nu: float
+        :param rho: Density of the material
+        :type rho: float
+        :param fy: Yield strength of the material, defaults to None
+        :type fy: float, optional
+        """
+
+        self.model: FEModel3D = model
+        self.name: str = name
+        self.E: float = E
+        self.G: float = G
+        self.nu: float = nu
+        self.rho: float = rho
+        self.fy: float | None = fy

--- a/Pynite/Mesh.py
+++ b/Pynite/Mesh.py
@@ -1,8 +1,14 @@
+from __future__ import annotations # Allows more recent type hints features
+from typing import TYPE_CHECKING
+from math import pi, sin, cos, ceil, isclose
+
 from Pynite.Node3D import Node3D
 from Pynite.Quad3D import Quad3D
 from Pynite.Plate3D import Plate3D
-from math import pi, sin, cos, ceil, isclose
-from bisect import bisect
+
+if TYPE_CHECKING:
+    from typing import List, Union, Dict
+    from Pynite.FEModel3D import FEModel3D
 
 #%%
 class Mesh():
@@ -10,7 +16,7 @@ class Mesh():
     A parent class for meshes to inherit from.
     """
 
-    def __init__(self, thickness, material_name, model, kx_mod=1, ky_mod=1, start_node='N1', start_element='Q1'):
+    def __init__(self, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1, ky_mod: float = 1, start_node: str = 'N1', start_element: str = 'Q1') -> None:
 
         self.thickness = thickness          # Thickness
         self.material_name = material_name            # The name of the element material
@@ -21,21 +27,21 @@ class Mesh():
         self.last_node = None               # The name of the last node in the mesh
         self.start_element = start_element  # The name of the first element in the mesh
         self.last_element = None            # The name of the last element in the mesh
-        self.nodes = {}                     # A dictionary containing the nodes in the mesh
-        self.elements = {}                  # A dictionary containing the elements in the mesh
+        self.nodes: Dict[str, Node3D] = {}  # A dictionary containing the nodes in the mesh
+        self.elements: Dict[str, Union[Quad3D, Plate3D]] = {}  # A dictionary containing the elements in the mesh
         self.element_type = 'Quad'          # The type of element used in the mesh
         self._is_generated = False          # A flag indicating whether the mesh has been generated
     
-    def is_generated(self):
+    def is_generated(self) -> bool:
         return self._is_generated
     
-    def _rename_duplicates(self):
+    def _rename_duplicates(self) -> None:
         """Renames any nodes or elements in the mesh that are already in the model
         """
 
         # Initialize lists to track node and element name changes
-        revised_nodes = {}
-        revised_elements = {}
+        revised_nodes: Dict[str, Node3D] = {}
+        revised_elements: Dict[str, Union[Quad3D, Plate3D]] = {}
 
         # Step through each node in the mesh
         for node in self.nodes.values():
@@ -85,13 +91,13 @@ class Mesh():
         self.nodes = revised_nodes
         self.elements = revised_elements
             
-    def generate(self):
+    def generate(self) -> None:
         """
         A placeholder to be overwritten by subclasses inheriting from this class
         """
         pass
 
-    def max_shear(self, direction='Qx', combo=None):
+    def max_shear(self, direction: str = 'Qx', combo: str | None = None) -> float:
         """
         Returns the maximum shear in the mesh.
         
@@ -100,6 +106,7 @@ class Mesh():
 
         Parameters
         ----------
+
         direction : string, optional
             The direction to ge the maximum shear for. Options are 'Qx' or 'Qy'. Default
             is 'Qx'.
@@ -155,14 +162,14 @@ class Mesh():
                                      element.shear((xi + xj)/2, (yi + yn)/2, local, load_combo.name)[i, 0]])
 
                     # Determine if the maximum shear calculated is the largest encountered so far
-                    if Q_max == None or Q_max < Q_element:
+                    if Q_max is None or Q_max < Q_element:
                         # Save this value if it's the largest
                         Q_max = Q_element
             
         # Return the largest value encountered from all the elements
-        return Q_max
+        return 0.0 if Q_max is None else Q_max
     
-    def min_shear(self, direction='Qx', combo=None):
+    def min_shear(self, direction: str = 'Qx', combo: str | None = None) -> float:
         """
         Returns the minimum shear in the mesh.
         
@@ -171,6 +178,7 @@ class Mesh():
 
         Parameters
         ----------
+
         direction : string, optional
             The direction to ge the minimum shear for. Options are 'Qx' or 'Qy'. Default
             is 'Qx'.
@@ -226,14 +234,14 @@ class Mesh():
                                      element.shear((xi + xj)/2, (yi + yn)/2, local, load_combo.name)[i, 0]])
 
                     # Determine if the minimum shear calculated is the smallest encountered so far
-                    if Q_min == None or Q_min > Q_element:
+                    if Q_min is None or Q_min > Q_element:
                         # Save this value if it's the smallest
                         Q_min = Q_element
             
         # Return the smallest value encountered from all the elements
-        return Q_min
+        return 0.0 if Q_min is None else Q_min
 
-    def max_moment(self, direction='Mx', combo=None):
+    def max_moment(self, direction: str = 'Mx', combo: str | None = None) -> float:
         """
         Returns the maximum moment in the mesh.
         
@@ -242,6 +250,7 @@ class Mesh():
 
         Parameters
         ----------
+
         direction : string, optional
             The direction to ge the maximum moment for. Options are 'Mx', 'My', or 'Mxy'. Default
             is 'Mx'.
@@ -299,14 +308,14 @@ class Mesh():
                                      element.moment((xi + xj)/2, (yi + yn)/2, local, load_combo.name)[i, 0]])
 
                     # Determine if the maximum moment calculated is the largest encountered so far
-                    if M_max == None or M_max < M_element:
+                    if M_max is None or M_max < M_element:
                         # Save this value if it's the largest
                         M_max = M_element
             
         # Return the largest value encountered from all the elements
-        return M_max
+        return 0.0 if M_max is None else M_max
     
-    def min_moment(self, direction='Mx', combo=None):
+    def min_moment(self, direction: str = 'Mx', combo: str | None = None) -> float:
         """
         Returns the minimum moment in the mesh.
         
@@ -315,6 +324,7 @@ class Mesh():
 
         Parameters
         ----------
+
         direction : string, optional
             The direction to ge the minimum moment for. Options are 'Mx', 'My', or 'Mxy'. Default
             is 'Mx'.
@@ -372,14 +382,14 @@ class Mesh():
                                      element.moment((xi + xj)/2, (yi + yn)/2, local, load_combo.name)[i, 0]])
 
                     # Determine if the minimum moment calculated is the smallest encountered so far
-                    if M_min == None or M_min > M_element:
+                    if M_min is None or M_min > M_element:
                         # Save this value if it's the smallest
                         M_min = M_element
             
         # Return the smallest value encountered from all the elements
-        return M_min
+        return 0.0 if M_min is None else M_min
     
-    def max_membrane(self, direction='Sx', combo=None):
+    def max_membrane(self, direction: str = 'Sx', combo: str | None = None) -> float:
         """
         Returns the maximum membrane stress in the mesh.
         
@@ -388,6 +398,7 @@ class Mesh():
 
         Parameters
         ----------
+
         direction : string, optional
             The direction to ge the maximum membrane force for. Options are 'Sx', 'Sy', or 'Sxy'. Default is 'Sx'.
         combo : string, optional
@@ -444,14 +455,14 @@ class Mesh():
                                         element.membrane((xi + xj)/2, (yi + yn)/2, local, load_combo.name)[i, 0]])
 
                     # Determine if the maximum membrane stress calculated is the largest encountered so far
-                    if S_max == None or S_max < M_element:
+                    if S_max is None or S_max < M_element:
                         # Save this value if it's the smallest
                         S_max = M_element
             
         # Return the smallest value encountered from all the elements
-        return S_max
+        return 0.0 if S_max is None else S_max
     
-    def min_membrane(self, direction='Sx', combo=None):
+    def min_membrane(self, direction: str = 'Sx', combo: str | None = None) -> float:
         """
         Returns the minimum membrane stress in the mesh.
         
@@ -460,6 +471,7 @@ class Mesh():
 
         Parameters
         ----------
+
         direction : string, optional
             The direction to ge the minimum membrane force for. Options are 'Sx', 'Sy', or 'Sxy'. Default is 'Sx'.
         combo : string, optional
@@ -516,22 +528,23 @@ class Mesh():
                                         element.membrane((xi + xj)/2, (yi + yn)/2, local, load_combo.name)[i, 0]])
 
                     # Determine if the minimum membrane stress calculated is the smallest encountered so far
-                    if S_min == None or S_min > M_element:
+                    if S_min is None or S_min > M_element:
                         # Save this value if it's the smallest
                         S_min = M_element
             
         # Return the smallest value encountered from all the elements
-        return S_min
+        return 0.0 if S_min is None else S_min
     
 #%%
 class RectangleMesh(Mesh):
 
-    def __init__(self, mesh_size, width, height, thickness, material_name, model, kx_mod=1, ky_mod=1, origin=[0, 0, 0], plane='XY', x_control=None, y_control=None, start_node='N1', start_element='Q1', element_type='Quad'):
+    def __init__(self, mesh_size: float, width: float, height: float, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1.0, ky_mod: float = 1.0, origin: List[float] = [0, 0, 0], plane: str = 'XY', x_control: List[float] | None = None, y_control: List[float] | None = None, start_node: str = 'N1', start_element: str = 'Q1', element_type: str = 'Quad') -> None:
         """
         A rectangular mesh of elements.
 
         Parameters
         ----------
+
         mesh_size : number
             Desired mesh size.
         width : number
@@ -570,6 +583,7 @@ class RectangleMesh(Mesh):
 
         Returns
         -------
+
         A new rectangular mesh object.
 
         """
@@ -588,9 +602,9 @@ class RectangleMesh(Mesh):
         else: self.y_control = y_control
 
         self.element_type = element_type
-        self.openings = {}
+        self.openings: Dict[str, RectOpening] = {}
     
-    def generate(self):
+    def generate(self) -> None:
 
         mesh_size = self.mesh_size
         width = self.width
@@ -850,7 +864,7 @@ class RectangleMesh(Mesh):
         # Flag the mesh as generated
         self._is_generated = True
 
-    def node_local_coords(self, node):
+    def node_local_coords(self, node: Node3D) -> tuple[float, float]:
         """
         Calculates a node's position in the mesh's local coordinate system
         """
@@ -867,12 +881,13 @@ class RectangleMesh(Mesh):
         
         return x, y
 
-    def add_rect_opening(self, name, x_left, y_bott, width, height):
+    def add_rect_opening(self, name: str, x_left: float, y_bott: float, width: float, height: float) -> None:
         """
         Adds a rectangular opening to the mesh.
 
         Parameters
         ----------
+
         name : string
             A unique name for the opening that can be used to access it later
             on.
@@ -903,10 +918,11 @@ class RectOpening():
     Represents a rectangular opening in a rectangular mesh.
     """
 
-    def __init__(self, x_left, y_bott, width, height):
+    def __init__(self, x_left: float, y_bott: float, width: float, height: float) -> None:
         """
         Parameters
         ----------
+
         x_left : number
             The x-coordinate for the left side of the opening in the mesh's
             local coordinate system.
@@ -930,8 +946,8 @@ class AnnulusMesh(Mesh):
     A mesh of quadrilaterals forming an annulus (a donut).
     """
 
-    def __init__(self, mesh_size, outer_radius, inner_radius, thickness, material_name, model, kx_mod=1,
-        ky_mod=1, origin=[0, 0, 0], axis='Y', start_node='N1', start_element='Q1'):
+    def __init__(self, mesh_size: float, outer_radius: float, inner_radius: float, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1,
+        ky_mod: float = 1, origin: List[float] = [0, 0, 0], axis: str = 'Y', start_node: str = 'N1', start_element: str = 'Q1') -> None:
 
         super().__init__(thickness, material_name, model, kx_mod, ky_mod, start_node, start_element)
 
@@ -946,7 +962,7 @@ class AnnulusMesh(Mesh):
         
         # self.generate()
     
-    def generate(self):
+    def generate(self) -> None:
         
         mesh_size = self.mesh_size
         r_outer = self.outer_radius
@@ -1027,8 +1043,8 @@ class AnnulusRingMesh(Mesh):
     A mesh of quadrilaterals forming an annular ring (a donut).
     """
 
-    def __init__(self, outer_radius, inner_radius, num_quads, thickness, material_name, model, kx_mod=1, ky_mod=1,
-                 origin=[0, 0, 0], axis='Y', start_node='N1', start_element='Q1'):
+    def __init__(self, outer_radius: float, inner_radius: float, num_quads: int, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1, ky_mod: float = 1,
+                 origin: List[float] = [0, 0, 0], axis: str = 'Y', start_node: str = 'N1', start_element: str = 'Q1') -> None:
 
         super().__init__(thickness, material_name, model, kx_mod, ky_mod, start_node=start_node,
                          start_element=start_element)
@@ -1045,7 +1061,7 @@ class AnnulusRingMesh(Mesh):
         # Generate the nodes and elements
         self.generate()
 
-    def generate(self):
+    def generate(self) -> None:
 
         n = self.n  # Number of plates in the initial ring
 
@@ -1153,12 +1169,13 @@ class AnnulusTransRingMesh(Mesh):
     edge.
     """
 
-    def __init__(self, outer_radius, inner_radius, num_inner_quads, thickness, material_name, model,
-                 kx_mod=1, ky_mod=1, origin=[0, 0, 0], axis='Y', start_node='N1',
-                 start_element='Q1'):
+    def __init__(self, outer_radius: float, inner_radius: float, num_inner_quads: int, thickness: float, material_name: str, model: FEModel3D,
+                 kx_mod: float = 1, ky_mod: float = 1, origin: List[float] = [0, 0, 0], axis: str = 'Y', start_node: str = 'N1',
+                 start_element: str = 'Q1') -> None:
         """
         Parameters
         ----------
+
         direction : array
             A vector indicating the direction normal to the ring.
         """
@@ -1178,7 +1195,7 @@ class AnnulusTransRingMesh(Mesh):
         # Create the mesh
         self.generate()
 
-    def generate(self):
+    def generate(self) -> None:
 
         n = self.n  # Number of plates in the outside of the ring (coarse mesh)
 
@@ -1329,8 +1346,8 @@ class FrustrumMesh(AnnulusMesh):
     A mesh of quadrilaterals forming a frustrum (a cone intersected by a horizontal plane).
     """
 
-    def __init__(self, mesh_size, large_radius, small_radius, height, thickness, material_name, model, kx_mod=1, ky_mod=1,
-                 origin=[0, 0, 0], axis='Y', start_node='N1', start_element='Q1'):
+    def __init__(self, mesh_size: float, large_radius: float, small_radius: float, height: float, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1, ky_mod: float = 1,
+                 origin: List[float] = [0, 0, 0], axis: str = 'Y', start_node: str = 'N1', start_element: str = 'Q1') -> None:
         
         # Create an annulus mesh
         super().__init__(mesh_size, large_radius, small_radius, thickness, material_name, model, kx_mod,
@@ -1338,7 +1355,7 @@ class FrustrumMesh(AnnulusMesh):
         
         self.height = height
     
-    def generate(self):
+    def generate(self) -> None:
 
         super().generate()
         
@@ -1381,6 +1398,7 @@ class CylinderMesh(Mesh):
 
     Parameters
     ----------
+
     mesh_size : number
         The desired mesh element edge size. This value will only be used to mesh vertically if `num_elements` is
         specified. Otherwise it will be used to mesh the circumference too.
@@ -1414,7 +1432,7 @@ class CylinderMesh(Mesh):
         The type of element to use for the mesh: 'Quad' or 'Rect'
     """
 
-    def __init__(self, mesh_size, radius, height, thickness, material_name, model, kx_mod=1, ky_mod=1,origin=[0, 0, 0], axis='Y', start_node='N1', start_element='Q1', num_elements=None, element_type='Quad'):
+    def __init__(self, mesh_size: float, radius: float, height: float, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1, ky_mod: float = 1,origin: List[float] = [0, 0, 0], axis: str = 'Y', start_node: str = 'N1', start_element: str = 'Q1', num_elements: int | None = None, element_type: str = 'Quad') -> None:
 
         # Inherit properties and methods from the parent `Mesh` class
         super().__init__(thickness, material_name, model, kx_mod, ky_mod, start_node, start_element)
@@ -1440,7 +1458,7 @@ class CylinderMesh(Mesh):
         # Generate the mesh
         self.generate()
     
-    def generate(self):
+    def generate(self) -> None:
         
         # Get the mesh thickness and the material name
         thickness = self.thickness
@@ -1522,6 +1540,7 @@ class CylinderRingMesh(Mesh):
 
     Parameters
     ----------
+
     radius : number
         Radius to the center of the plates in the cylindrical ring.
     height : number
@@ -1555,9 +1574,9 @@ class CylinderRingMesh(Mesh):
     
     """
 
-    def __init__(self, radius, height, num_elements, thickness, material_name, model, kx_mod=1, ky_mod=1,
-                 origin=[0, 0, 0], axis='Y', start_node='N1', start_element='Q1',
-                 element_type='Quad'):
+    def __init__(self, radius: float, height: float, num_elements: int, thickness: float, material_name: str, model: FEModel3D, kx_mod: float = 1, ky_mod: float = 1,
+                 origin: List[float] = [0, 0, 0], axis: str = 'Y', start_node: str = 'N1', start_element: str = 'Q1',
+                 element_type: str = 'Quad') -> None:
 
         super().__init__(thickness, material_name, model, kx_mod, ky_mod, start_node=start_node, start_element=start_element)
 
@@ -1573,7 +1592,7 @@ class CylinderRingMesh(Mesh):
         # Generate the nodes and elements
         self.generate()
 
-    def generate(self):
+    def generate(self) -> None:
         """
         Generates the nodes and elements in the mesh.
         """
@@ -1698,7 +1717,7 @@ class CylinderRingMesh(Mesh):
         # Flag the mesh as generated
         self._is_generated = True
         
-def check_mesh_integrity(mesh, console_log=True):
+def check_mesh_integrity(mesh: Mesh, console_log: bool = True) -> Union[str, List[str], None]:
     """Runs basic integrity checks to ensure the mesh is in sync with its model. Usually you don't
     want to run this check unless the mesh has been generated since generating the mesh is what
     syncs it to the model.

--- a/Pynite/Node3D.py
+++ b/Pynite/Node3D.py
@@ -4,13 +4,16 @@ Created on Thu Nov  2 18:04:56 2017
 
 @author: D. Craig Brinck, SE
 """
+from __future__ import annotations # Allows more recent type hints features
 # %%      
+from typing import List, Tuple, Dict
+
 class Node3D():
     """
     A class representing a node in a 3D finite element model.
     """
     
-    def __init__(self, name, X, Y, Z):
+    def __init__(self, name: str, X: float, Y: float, Z: float):
         
         self.name = name    # A unique name for the node assigned by the user
         self.ID = None      # A unique index number for the node assigned by the program
@@ -19,52 +22,52 @@ class Node3D():
         self.Y = Y          # Global Y coordinate
         self.Z = Z          # Global Z coordinate
         
-        self.NodeLoads = [] # A list of loads applied to the node (Direction, P, case) or (Direction, M, case)
+        self.NodeLoads: List[Tuple[str, float, str]] = [] # A list of loads applied to the node (Direction, P, case) or (Direction, M, case)
         
         # Initialize the dictionaries of calculated node displacements
-        self.DX = {}
-        self.DY = {}
-        self.DZ = {}
-        self.RX = {}
-        self.RY = {}
-        self.RZ = {}
+        self.DX: Dict[str, float] = {}
+        self.DY: Dict[str, float] = {}
+        self.DZ: Dict[str, float] = {}
+        self.RX: Dict[str, float] = {}
+        self.RY: Dict[str, float] = {}
+        self.RZ: Dict[str, float] = {}
         
         # Initialize the dictionaries of calculated node reactions
-        self.RxnFX = {}
-        self.RxnFY = {}
-        self.RxnFZ = {}
-        self.RxnMX = {}
-        self.RxnMY = {}
-        self.RxnMZ = {}
+        self.RxnFX: Dict[str, float] = {}
+        self.RxnFY: Dict[str, float] = {}
+        self.RxnFZ: Dict[str, float] = {}
+        self.RxnMX: Dict[str, float] = {}
+        self.RxnMY: Dict[str, float] = {}
+        self.RxnMZ: Dict[str, float] = {}
 
         # Initialize all support conditions to `False`
-        self.support_DX = False
-        self.support_DY = False
-        self.support_DZ = False
-        self.support_RX = False
-        self.support_RY = False
-        self.support_RZ = False
+        self.support_DX: bool = False
+        self.support_DY: bool = False
+        self.support_DZ: bool = False
+        self.support_RX: bool = False
+        self.support_RY: bool = False
+        self.support_RZ: bool = False
 
         # Inititialize all support springs
-        self.spring_DX = [None, None, None]  # [stiffness, direction, active]
-        self.spring_DY = [None, None, None]
-        self.spring_DZ = [None, None, None]
-        self.spring_RX = [None, None, None]
-        self.spring_RY = [None, None, None]
-        self.spring_RZ = [None, None, None]
+        self.spring_DX: List[float | str | bool | None] = [None, None, None]  # [stiffness, direction, active]
+        self.spring_DY: List[float | str | bool | None] = [None, None, None]
+        self.spring_DZ: List[float | str | bool | None] = [None, None, None]
+        self.spring_RX: List[float | str | bool | None] = [None, None, None]
+        self.spring_RY: List[float | str | bool | None] = [None, None, None]
+        self.spring_RZ: List[float | str | bool | None] = [None, None, None]
 
         # Initialize all enforced displacements to `None`
-        self.EnforcedDX = None
-        self.EnforcedDY = None
-        self.EnforcedDZ = None
-        self.EnforcedRX = None
-        self.EnforcedRY = None
-        self.EnforcedRZ = None
+        self.EnforcedDX: float | None = None
+        self.EnforcedDY: float | None = None
+        self.EnforcedDZ: float | None = None
+        self.EnforcedRX: float | None = None
+        self.EnforcedRY: float | None = None
+        self.EnforcedRZ: float | None = None
 
         # Initialize the color contour value for the node. This will be used for contour smoothing.
-        self.contour = []
+        self.contour: List[float] = []
 
-    def distance(self, other):
+    def distance(self, other: 'Node3D') -> float:
         """
         Returns the distance to another node.
 

--- a/Pynite/Quad3D.py
+++ b/Pynite/Quad3D.py
@@ -3,11 +3,20 @@
 # 2. "Finite Element Procedures, 2nd Edition", Klaus-Jurgen Bathe
 # 3. "A First Course in the Finite Element Method, 4th Edition", Daryl L. Logan
 # 4. "Finite Element Analysis Fundamentals", Richard H. Gallagher
+from __future__ import annotations # Allows more recent type hints features
+from math import sin, cos
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from numpy import add
 from numpy.linalg import inv, det, norm
-from math import sin, cos
+
+if TYPE_CHECKING:
+    from typing import List, Tuple, Optional
+    from numpy import float64
+    from numpy.typing import NDArray
+    from Pynite.FEModel3D import FEModel3D
+    from Pynite.Node3D import Node3D
 
 class Quad3D():
     """
@@ -16,31 +25,32 @@ class Quad3D():
     This element performs well for thick and thin plates, and for skewed plates. Minor errors are introduced into the solution due to the drilling approximation. Orthotropic behavior is limited to acting along the plate's local axes.
     """
 
-    def __init__(self, name, i_node, j_node, m_node, n_node, t, material_name, model, kx_mod=1.0,
-                 ky_mod=1.0):
+    def __init__(self, name: str, i_node: Node3D, j_node: Node3D, m_node: Node3D, n_node: Node3D, 
+                 t: float, material_name: str, model: FEModel3D, kx_mod: float = 1.0,
+                 ky_mod: float = 1.0):
 
-        self.name = name
-        self.ID = None
-        self.type = 'Quad'
+        self.name: str = name
+        self.ID: Optional[int] = None
+        self.type: str = 'Quad'
 
-        self.i_node = i_node
-        self.j_node = j_node
-        self.m_node = m_node
-        self.n_node = n_node
+        self.i_node: Node3D = i_node
+        self.j_node: Node3D = j_node
+        self.m_node: Node3D = m_node
+        self.n_node: Node3D = n_node
 
-        self.t = t
-        self.kx_mod = kx_mod
-        self.ky_mod = ky_mod
+        self.t: float = t
+        self.kx_mod: float = kx_mod
+        self.ky_mod: float = ky_mod
 
-        self.pressures = []  # A list of surface pressures [pressure, case='Case 1']
+        self.pressures: List[Tuple[float, str]] = []  # A list of surface pressures [pressure, case='Case 1']
     
         # Quads need a link to the model they belong to
-        self.model = model
+        self.model: FEModel3D = model
 
         # Get material properties for the plate from the model
         try:
-            self.E = self.model.materials[material_name].E
-            self.nu = self.model.materials[material_name].nu
+            self.E: float = self.model.materials[material_name].E
+            self.nu: float = self.model.materials[material_name].nu
         except:
             raise KeyError('Please define the material ' + str(material_name) + ' before assigning it to plates.')
 
@@ -116,16 +126,16 @@ class Quad3D():
         y_axis = y_axis/norm(y_axis)
 
         # Calculate the local (x, y) coordinates for each node
-        self.x1 = 0
-        self.x2 = np.dot(vector_12, x_axis)
-        self.x3 = np.dot(vector_13, x_axis)
-        self.x4 = np.dot(vector_14, x_axis)
-        self.y1 = 0
-        self.y2 = np.dot(vector_12, y_axis)
-        self.y3 = np.dot(vector_13, y_axis)
-        self.y4 = np.dot(vector_14, y_axis)
+        self.x1: float = 0.0
+        self.x2: float = np.dot(vector_12, x_axis)
+        self.x3: float = np.dot(vector_13, x_axis)
+        self.x4: float = np.dot(vector_14, x_axis)
+        self.y1: float = 0.0
+        self.y2: float = np.dot(vector_12, y_axis)
+        self.y3: float = np.dot(vector_13, y_axis)
+        self.y4: float = np.dot(vector_14, y_axis)
 
-    def L_k(self, k):
+    def L_k(self, k: Literal[5, 6, 7, 8]) -> float:
         
         # Figures 3 and 5
         if k == 5:
@@ -139,7 +149,7 @@ class Quad3D():
         else:
             raise Exception('Invalid value for k. k must be 5, 6, 7, or 8.')
     
-    def dir_cos(self, k):
+    def dir_cos(self, k: Literal[5, 6, 7, 8]) -> Tuple[float, float]:
 
         L_k = self.L_k(k)
 
@@ -161,14 +171,14 @@ class Quad3D():
 
         return C, S
 
-    def phi_k(self, k):
+    def phi_k(self, k: Literal[5, 6, 7, 8]) -> float:
 
         kappa = 5/6
 
         # Equation 74
         return 2/(kappa*(1-self.nu))*(self.t/self.L_k(k))**2
 
-    def N_i(self, i, xi, eta):
+    def N_i(self, i: Literal[1, 2, 3, 4], xi: float, eta: float) -> float:
         """
         Returns the interpolation function for any given coordinate in the natural (xi, eta) coordinate system
         """
@@ -184,7 +194,7 @@ class Quad3D():
         else:
             raise Exception('Unable to calculate interpolation function. Invalid value specifed for i.')
     
-    def P_k(self, k, xi, eta):
+    def P_k(self, k: Literal[5, 6, 7, 8], xi: float, eta: float) -> float:
 
         if k == 5:
             return 1/2*(1 - xi**2)*(1 - eta)
@@ -197,7 +207,7 @@ class Quad3D():
         else:
             raise Exception('Unable to calculate shape function. Invalid value specified for k.')
     
-    def Co(self, xi, eta):
+    def Co(self, xi: float, eta: float) -> NDArray[float64]:
         """
         This alternate calculation of the Jacobian matrix follows "The development of DKMQ plate bending element for thick to thin shell analysis based on the Naghdi/Reissner/Mindlin shell theory" by Katili, Batoz, Maknun and Hamdouni (2015). In the reference "C^o" is used instead of "J" to refer to the Jacobian. This method does not seem to produce incorrect results, but will be kept for future reference. It is helpful for understanding this plate element and may prove a useful simplification to the code base if implemented correctly someday.
         """
@@ -258,7 +268,7 @@ class Quad3D():
         
         return Co
 
-    def J(self, xi, eta):
+    def J(self, xi: float, eta: float) -> NDArray[float64]:
         """
         Returns the Jacobian matrix for the element
         """
@@ -270,13 +280,13 @@ class Quad3D():
         return 1/4*np.array([[x1*(eta - 1) - x2*(eta - 1) + x3*(eta + 1) - x4*(eta + 1), y1*(eta - 1) - y2*(eta - 1) + y3*(eta + 1) - y4*(eta + 1)],
                              [x1*(xi - 1)  - x2*(xi + 1)  + x3*(xi + 1)  - x4*(xi - 1),  y1*(xi - 1)  - y2*(xi + 1)  + y3*(xi + 1)  - y4*(xi - 1)]])
 
-    def N_gamma(self, xi, eta):
+    def N_gamma(self, xi: float, eta: float) -> NDArray[float64]:
 
         # Equation 44
         return np.array([[1/2*(1 - eta),       0,      1/2*(1 + eta),       0     ],
                          [     0,        1/2*(1 + xi),       0,       1/2*(1 - xi)]])
 
-    def A_gamma(self):
+    def A_gamma(self) -> NDArray[float64]:
 
         L5 = self.L_k(5)
         L6 = self.L_k(6)
@@ -289,7 +299,7 @@ class Quad3D():
                          [  0,    0,  -L7/2,    0 ],
                          [  0,    0,     0,  -L8/2]])
 
-    def A_u(self):
+    def A_u(self) -> NDArray[float64]:
 
         # Calculate the length of each side of the quad
         L5 = self.L_k(5)
@@ -309,7 +319,7 @@ class Quad3D():
                              [  0,    0,  0,   0,    0,  0, -2/L7, C7, S7,  2/L7, C7, S7],
                              [ 2/L8, C8, S8,   0,    0,  0,   0,    0,  0, -2/L8, C8, S8]])
 
-    def A_Delta_inv_DKMQ(self):
+    def A_Delta_inv_DKMQ(self) -> NDArray[float64]:
 
         phi5 = self.phi_k(5)
         phi6 = self.phi_k(6)
@@ -321,7 +331,7 @@ class Quad3D():
                               [   0,           0,      1/(1+phi7),     0     ],
                               [   0,           0,          0,      1/(1+phi8)]])
 
-    def A_phi_Delta(self):
+    def A_phi_Delta(self) -> NDArray[float64]:
 
         phi5 = self.phi_k(5)
         phi6 = self.phi_k(6)
@@ -333,7 +343,7 @@ class Quad3D():
                          [      0,             0,       phi7/(1+phi7),       0      ],
                          [      0,             0,             0,       phi8/(1+phi8)]])
     
-    def B_b_beta(self, xi, eta):
+    def B_b_beta(self, xi: float, eta: float) -> NDArray[float64]:
 
         # Get the inverse of the Jacobian matrix
         J_inv = inv(self.J(xi, eta))
@@ -367,7 +377,7 @@ class Quad3D():
                          [0,  0,  N1y, 0,  0,  N2y, 0,  0,  N3y, 0,  0,  N4y],
                          [0, N1y, N1x, 0, N2y, N2x, 0, N3y, N3x, 0, N4y, N4x]])
     
-    def B_b_Delta_beta(self, xi, eta):
+    def B_b_Delta_beta(self, xi: float, eta: float) -> NDArray[float64]:
 
         # Get the inverse of the Jacobian matrix
         J_inv = inv(self.J(xi, eta))
@@ -406,7 +416,7 @@ class Quad3D():
                          [    P5y*S5,          P6y*S6,          P7y*S7,          P8y*S8,    ],
                          [P5y*C5 + P5x*S5, P6y*C6 + P6x*S6, P7y*C7 + P7x*S7, P8y*C8 + P8x*S8]])
     
-    def B_b(self, xi, eta):
+    def B_b(self, xi: float, eta: float) -> NDArray[float64]:
         """
         Returns the [B_b] matrix for bending
         """
@@ -414,7 +424,7 @@ class Quad3D():
         # Return the [B] matrix for bending
         return add(self.B_b_beta(xi, eta), self.B_b_Delta_beta(xi, eta) @ self.A_Delta_inv_DKMQ() @ self.A_u())
 
-    def B_s(self, xi, eta):
+    def B_s(self, xi: float, eta: float) -> NDArray[float64]:
         """
         Returns the [B_s] matrix for shear
         """
@@ -422,7 +432,7 @@ class Quad3D():
         # Return the [B] matrix for shear
         return inv(self.J(xi, eta)) @ self.N_gamma(xi, eta) @ self.A_gamma() @ self.A_phi_Delta() @ self.A_u()
 
-    def B_s_gamma(self, xi, eta):
+    def B_s_gamma(self, xi:float , eta: float) -> None:
         """Returns the [B_s_gamma] matrix for shear (Equation 39 in Reference 1)
 
         :param xi: _description_
@@ -430,8 +440,9 @@ class Quad3D():
         :param eta: _description_
         :type eta: _type_
         """
+        raise NotImplementedError('This function is not implemented yet. It is not needed for the current implementation of the Quad3D element.')
 
-    def B_m(self, xi, eta):
+    def B_m(self, xi: float, eta: float) -> NDArray[float64]:
 
         # Differentiate the interpolation functions
         # Row 1 = interpolation functions differentiated with respect to x
@@ -448,7 +459,7 @@ class Quad3D():
 
         return B_m
 
-    def Hb(self):
+    def Hb(self) -> NDArray[float64]:
         '''
         Returns the stress-strain matrix for plate bending.
         '''
@@ -464,7 +475,7 @@ class Quad3D():
         
         return Hb
 
-    def Hs(self):
+    def Hs(self) -> NDArray[float64]:
         '''
         Returns the stress-strain matrix for shear.
         '''
@@ -479,7 +490,7 @@ class Quad3D():
 
         return Hs
 
-    def Cm(self):
+    def Cm(self) -> NDArray[float64]:
         """
         Returns the stress-strain matrix for an isotropic or orthotropic plane stress element
         """
@@ -504,7 +515,7 @@ class Quad3D():
         
         return Cm
 
-    def k_b(self):
+    def k_b(self) -> NDArray[float64]:
         '''
         Returns the local stiffness matrix for bending stresses
         '''
@@ -614,7 +625,7 @@ class Quad3D():
 
         return k_exp
 
-    def k_m(self):
+    def k_m(self) -> NDArray[float64]:
         '''
         Returns the local stiffness matrix for membrane (in-plane) stresses.
 
@@ -672,7 +683,7 @@ class Quad3D():
         
         return k_exp
 
-    def k(self):
+    def k(self) -> NDArray[float64]:
         '''
         Returns the quad element's local stiffness matrix.
         '''
@@ -683,7 +694,7 @@ class Quad3D():
         # Sum the bending and membrane stiffness matrices
         return np.add(self.k_b(), self.k_m())
    
-    def f(self, combo_name='Combo 1'):
+    def f(self, combo_name:str='Combo 1') -> NDArray[float64]:
         """
         Returns the quad element's local end force vector
         """
@@ -691,7 +702,7 @@ class Quad3D():
         # Calculate and return the plate's local end force vector
         return np.add(self.k() @ self.d(combo_name), self.fer(combo_name))
 
-    def fer(self, combo_name='Combo 1'):
+    def fer(self, combo_name:str='Combo 1') -> NDArray[float64]:
         """
         Returns the quadrilateral's local fixed end reaction vector.
 
@@ -757,7 +768,7 @@ class Quad3D():
 
         return fer_exp
 
-    def d(self, combo_name='Combo 1'):
+    def d(self, combo_name='Combo 1') -> NDArray[float64]:
        """
        Returns the quad element's local displacement vector
        """
@@ -765,7 +776,7 @@ class Quad3D():
        # Calculate and return the local displacement vector
        return self.T() @ self.D(combo_name)
 
-    def F(self, combo_name='Combo 1'):
+    def F(self, combo_name:str='Combo 1') -> NDArray[float64]:
         """
         Returns the quad element's global force vector
 
@@ -778,7 +789,7 @@ class Quad3D():
         # Calculate and return the global force vector
         return inv(self.T()) @ self.f(combo_name)
 
-    def D(self, combo_name='Combo 1'):
+    def D(self, combo_name:str='Combo 1') -> NDArray[float64]:
         '''
         Returns the quad element's global displacement vector for the given
         load combination.
@@ -825,7 +836,7 @@ class Quad3D():
         # Return the global displacement vector
         return D
 
-    def K(self):
+    def K(self) -> NDArray[float64]:
         '''
         Returns the quad element's global stiffness matrix
         '''
@@ -837,7 +848,7 @@ class Quad3D():
         return inv(T) @ self.k() @ T
  
     # Global fixed end reaction vector
-    def FER(self, combo_name='Combo 1'):
+    def FER(self, combo_name:str='Combo 1') -> NDArray[float64]:
         '''
         Returns the global fixed end reaction vector.
 
@@ -851,7 +862,7 @@ class Quad3D():
         # Calculate and return the fixed end reaction vector
         return inv(self.T()) @ self.fer(combo_name)
   
-    def T(self):
+    def T(self) -> NDArray[float64]:
         """
         Returns the coordinate transformation matrix for the quad element.
         """
@@ -984,7 +995,7 @@ class Quad3D():
     #     # Return the transformation matrix.
     #     return T
     
-    def shear(self, xi=0, eta=0, local=True, combo_name='Combo 1'):
+    def shear(self, xi:float=0.0, eta:float=0.0, local:bool=True, combo_name:str='Combo 1') -> NDArray[float64]:
         """
         Returns the interal shears at any point in the quad element.
 
@@ -993,9 +1004,9 @@ class Quad3D():
 
         Parameters
         ----------
-        xi : number
+        xi : float
             The xi-coordinate. Default is 0.
-        eta : number
+        eta : float
             The eta-coordinate. Default is 0.
         
         Returns
@@ -1049,7 +1060,7 @@ class Quad3D():
                                                   Qy,
                                                   [0]]))
    
-    def moment(self, xi=0, eta=0, local=True, combo_name='Combo 1'):
+    def moment(self, xi:float=0.0, eta:float=0.0, local:bool=True, combo_name:str='Combo 1') -> NDArray[float64]:
         """
         Returns the interal moments at any point in the quad element.
 
@@ -1058,9 +1069,9 @@ class Quad3D():
 
         Parameters
         ----------
-        xi : number
+        xi : float
             The xi-coordinate. Default is 0.
-        eta : number
+        eta : float
             The eta-coordinate. Default is 0.
         
         Returns
@@ -1121,7 +1132,7 @@ class Quad3D():
 
             return M_global
 
-    def membrane(self, xi=0, eta=0, local=True, combo_name='Combo 1'):
+    def membrane(self, xi:float=0, eta: float=0, local:bool=True, combo_name:str='Combo 1') -> NDArray[float64]:
         
         # Get the plate's local displacement vector. Slice out terms not related to membrane stresses.
         d = self.d(combo_name)[[0, 1, 6, 7, 12, 13, 18, 19], :]

--- a/Pynite/Rendering.py
+++ b/Pynite/Rendering.py
@@ -1,11 +1,20 @@
-
+from __future__ import annotations # Allows more recent type hints features
 from json import load
 import warnings
+from typing import TYPE_CHECKING
 
 from IPython.display import Image
 import numpy as np
 import pyvista as pv
 import math
+
+# For type checking only - these imports are only used during type checking
+if TYPE_CHECKING:
+    from typing import List, Union, Tuple, Optional
+    from Pynite.Node3D import Node3D
+    from Pynite.Member3D import Member3D
+    from Pynite.Spring3D import Spring3D
+    from Pynite.FEModel3D import FEModel3D
 
 # Allow for 3D interaction within jupyter notebook using trame
 try:
@@ -19,27 +28,27 @@ class Renderer:
     """Used to render finite element models.
     """
 
-    scalar = None
+    scalar: Optional[str] = None
 
-    def __init__(self, model):
+    def __init__(self, model: FEModel3D) -> None:
 
-        self.model = model
+        self.model: FEModel3D = model
 
         # Default settings for rendering
-        self._annotation_size = 5
-        self._deformed_shape = False
-        self._deformed_scale = 30
-        self._render_nodes = True
-        self._render_loads = True
-        self._color_map = None
-        self._combo_name = 'Combo 1'
-        self._case = None
-        self._labels = True
-        self._scalar_bar = False
-        self._scalar_bar_text_size = 24
-        self.theme = 'default'
+        self._annotation_size: float = 5.0
+        self._deformed_shape: bool = False
+        self._deformed_scale: float = 30.0
+        self._render_nodes: bool = True
+        self._render_loads: bool = True
+        self._color_map: Optional[str] = None
+        self._combo_name: Optional[str] = 'Combo 1'
+        self._case: Optional[str] = None
+        self._labels: bool = True
+        self._scalar_bar: bool = False
+        self._scalar_bar_text_size: int = 24
+        self.theme: str = 'default'
 
-        self.plotter = pv.Plotter()
+        self.plotter: pv.Plotter = pv.Plotter()
         self.plotter.set_background('white')  # Setting background color
         # self.plotter.add_logo_widget('./Resources/Full Logo No Buffer - Transparent.png')
         # self.plotter.view_isometric()
@@ -47,130 +56,127 @@ class Renderer:
         self.plotter.show_axes()
 
         # Initialize load labels
-        self._load_label_points = []
-        self._load_labels = []
+        self._load_label_points: List[List[float]] = []
+        self._load_labels: List[Union[str, float, int]] = []
 
         # Initialize spring labels
-        self._spring_label_points = []
-        self._spring_labels = []
+        self._spring_label_points: List[List[float]] = []
+        self._spring_labels: List[str] = []
 
     @property
-    def window_width(self):
+    def window_width(self) -> int:
         return self.plotter.window_size[0]
 
     @window_width.setter
-    def window_width(self, width):
+    def window_width(self, width: int) -> None:
         height = self.plotter.window_size[1]
         self.plotter.window_size = (width, height)
 
     @property
-    def window_height(self):
+    def window_height(self) -> int:
         return self.plotter.window_size[1]
 
     @window_height.setter
-    def window_height(self, height):
+    def window_height(self, height: int) -> None:
         width = self.plotter.window_size[0]
         self.plotter.window_size = (width, height)
 
     @property
-    def annotation_size(self):
+    def annotation_size(self) -> float:
         return self._annotation_size
     
     @annotation_size.setter
-    def annotation_size(self, size):
+    def annotation_size(self, size: float) -> None:
         self._annotation_size = size
     
     @property
-    def deformed_shape(self):
+    def deformed_shape(self) -> bool:
         return self._deformed_shape
     
     @deformed_shape.setter
-    def deformed_shape(self, deformed_shape):
+    def deformed_shape(self, deformed_shape: bool) -> None:
         self._deformed_shape = deformed_shape
     
     @property
-    def deformed_scale(self):
+    def deformed_scale(self) -> float:
         return self._deformed_scale
     
     @deformed_scale.setter
-    def deformed_scale(self, scale):
+    def deformed_scale(self, scale: float) -> None:
         self._deformed_scale = scale
     
     @property
-    def render_nodes(self):
+    def render_nodes(self) -> bool:
         return self._render_nodes
     
     @render_nodes.setter
-    def render_nodes(self, render_nodes):
+    def render_nodes(self, render_nodes: bool) -> None:
         self._render_nodes = render_nodes
 
     @property
-    def render_loads(self):
+    def render_loads(self) -> bool:
         return self._render_loads
     
     @render_loads.setter
-    def render_loads(self, render_loads):
+    def render_loads(self, render_loads: bool) -> None:
         self._render_loads = render_loads
     
     @property
-    def color_map(self):
+    def color_map(self) -> Optional[str]:
         return self._color_map
     
     @color_map.setter
-    def color_map(self, color_map):
+    def color_map(self, color_map: Optional[str]) -> None:
         self._color_map = color_map
     
     @property
-    def combo_name(self):
+    def combo_name(self) -> Optional[str]:
         return self._combo_name
     
     @combo_name.setter
-    def combo_name(self, combo_name):
+    def combo_name(self, combo_name: Optional[str]) -> None:
         self._combo_name = combo_name
         self._case = None
     
     @property
-    def case(self):
+    def case(self) -> Optional[str]:
         return self._case
     
     @case.setter
-    def case(self, case):
+    def case(self, case: Optional[str]) -> None:
         self._case = case
         self._combo_name = None
     
     @property
-    def show_labels(self):
+    def show_labels(self) -> bool:
         return self._labels
     
     @show_labels.setter
-    def show_labels(self, show_labels):
+    def show_labels(self, show_labels: bool) -> None:
         self._labels = show_labels
     
     @property
-    def scalar_bar(self):
+    def scalar_bar(self) -> bool:
         return self._scalar_bar
     
     @scalar_bar.setter
-    def scalar_bar(self, scalar_bar):
+    def scalar_bar(self, scalar_bar: bool) -> None:
         self._scalar_bar = scalar_bar
     
     @property
-    def scalar_bar_text_size(self):
+    def scalar_bar_text_size(self) -> int:
         return self._scalar_bar_text_size
     
     @scalar_bar_text_size.setter
-    def scalar_bar_text_size(self, text_size):
+    def scalar_bar_text_size(self, text_size: int) -> None:
         self._scalar_bar_text_size = text_size
 
-    def render_model(self, reset_camera=True):
+    def render_model(self, reset_camera: bool = True) -> None:
         """
         Renders the model in a window
 
         Parameters
         ----------
-        interact : bool
-            Suppresses interacting with the window if set to `False`. This can be used to capture a
-            screenshot without pausing the program for the user to interact. Default is `True`.
         reset_camera : bool
             Resets the camera if set to `True`. Default is `True`.
         """
@@ -181,7 +187,7 @@ class Renderer:
         # Render the model (code execution will pause here until the user closes the window)
         self.plotter.show(title='Pynite - Simple Finite Element Analysis for Python', auto_close=False)
 
-    def screenshot(self, filepath='./Pynite_Image.png', interact=True, reset_camera=True):
+    def screenshot(self, filepath: str = './Pynite_Image.png', interact: bool = True, reset_camera: bool = True) -> None:
         """Saves a screenshot of the rendered model. Important: Press `q` to capture the screenshot after positioning the view. Pressing the `X` button in the corner of the window will ignore the positioning and shut down the entire renderer against further use once the screenshot is taken.
 
         :param filepath: The filepath to write the image to. When set to 'jupyter', the resulting plot is placed inline in a jupyter notebook. Defaults to 'jupyter'.
@@ -204,7 +210,7 @@ class Renderer:
         # Save the screenshot to the specified filepath. Note that `auto_close` shuts down the entire plotter after the screenshot is taken, rather than just closing the window. We'll set `auto_close=False` to allow the plotter to remain active. Note that the window must be closed by pressing `q`. Closing it with the 'X' button in the window's corner will close the whole plotter down.
         self.plotter.show(title='Pynite - Simple Finite Element Anlaysis for Python', screenshot=filepath, auto_close=False)
 
-    def update(self, reset_camera=True):
+    def update(self, reset_camera: bool = True) -> None:
         """
         Builds or rebuilds the pyvista plotter
 
@@ -307,7 +313,7 @@ class Renderer:
         if reset_camera:
             self.plotter.reset_camera()
     
-    def plot_node(self, node, color='grey'):
+    def plot_node(self, node: Node3D, color: str = 'grey') -> None:
         """Adds a node to the plotter
 
         :param node: node
@@ -475,7 +481,7 @@ class Renderer:
                                               z_length=self.annotation_size*0.6),
                                       color=color)
 
-    def plot_member(self, member, theme='default'):
+    def plot_member(self, member: Member3D, theme: str = 'default') -> None:
         """
         Adds a member to the plotter. This method generates a line representing a structural member between two nodes, and adds it to the plotter with specified theme settings.
         
@@ -502,7 +508,7 @@ class Renderer:
 
         self.plotter.add_mesh(line, color='black', line_width=2)
 
-    def plot_spring(self, spring, color='grey', deformed=False):
+    def plot_spring(self, spring: Spring3D, color: str = 'grey', deformed: bool = False) -> None:
         """
         Adds a spring to the plotter. This method generates a zig-zag line representing a spring between two nodes, and adds it to the plotter with specified theme settings.
         """
@@ -585,7 +591,7 @@ class Renderer:
         self._spring_label_points.append([(Xi + Xj) / 2, (Yi + Yj) / 2, (Zi + Zj) / 2])
 
             
-    def plot_plates(self, deformed_shape, deformed_scale, color_map, combo_name):
+    def plot_plates(self, deformed_shape: bool, deformed_scale: float, color_map: Optional[str], combo_name: Optional[str]) -> None:
         
         # Start a list of vertices
         plate_vertices = []
@@ -672,7 +678,7 @@ class Renderer:
         else:
             self.plotter.add_mesh(plate_polydata)
       
-    def plot_deformed_node(self, node, scale_factor, color='grey'):
+    def plot_deformed_node(self, node: Node3D, scale_factor: float, color: str = 'grey') -> None:
 
         # Calculate the node's deformed position
         newX = node.X + scale_factor * (node.DX[self.combo_name])
@@ -685,7 +691,7 @@ class Renderer:
         # Add the mesh to the plotter
         self.plotter.add_mesh(sphere, color=color)
   
-    def plot_deformed_member(self, member, scale_factor):
+    def plot_deformed_member(self, member: Member3D, scale_factor: float) -> None:
         
         # Determine if this member is active for each load combination
         if member.active:
@@ -740,7 +746,8 @@ class Renderer:
                 line = pv.Line(D_plot[i], D_plot[i+1])
                 self.plotter.add_mesh(line, color='red', line_width=2)
 
-    def plot_pt_load(self, position, direction, length, label_text=None, color='green'):
+    def plot_pt_load(self, position: Tuple[float, float, float], direction: Union[Tuple[float, float, float], np.ndarray], 
+                    length: float, label_text: Optional[Union[str, float, int]] = None, color: str = 'green') -> None:
 
         # Create a unit vector in the direction of the 'direction' vector
         unitVector = direction/np.linalg.norm(direction)
@@ -777,7 +784,10 @@ class Renderer:
         # Plot the shaft
         self.plotter.add_mesh(shaft, line_width=2, color=color)                         
 
-    def plot_dist_load(self, position1, position2, direction, length1, length2, label_text1, label_text2, color='green'):
+    def plot_dist_load(self, position1: Tuple[float, float, float], position2: Tuple[float, float, float], 
+                      direction: Union[np.ndarray, Tuple[float, float, float]], length1: float, length2: float,
+                      label_text1: Optional[Union[str, float, int]], label_text2: Optional[Union[str, float, int]], 
+                      color: str = 'green') -> None:
 
         # Calculate the length of the distributed load
         load_length = ((position2[0] - position1[0])**2 + (position2[1] - position1[1])**2 + (position2[2] - position1[2])**2)**0.5
@@ -827,7 +837,8 @@ class Renderer:
         # Combine all geometry into a single PolyData object
         self.plotter.add_mesh(tail_line, color=color)
 
-    def plot_moment(self, center, direction, radius, label_text=None, color='green'):
+    def plot_moment(self, center: Tuple[float, float, float], direction: Union[Tuple[float, float, float], np.ndarray], 
+                    radius: float, label_text: Optional[Union[str, float, int]] = None, color: str = 'green') -> None:
 
         # Convert the direction vector into a unit vector
         v1 = direction/np.linalg.norm(direction)

--- a/Pynite/Reporting.py
+++ b/Pynite/Reporting.py
@@ -1,7 +1,12 @@
 # Import libraries necessary for report printing
+from __future__ import annotations # Allows more recent type hints features
+from typing import TYPE_CHECKING
+
 from jinja2 import Environment, PackageLoader
 import pdfkit
 
+if TYPE_CHECKING:
+    from Pynite import FEModel3D
 
 # Determine the filepath to the local Pynite installation
 from pathlib import Path
@@ -15,14 +20,14 @@ env = Environment(
 # Get the report template
 template = env.get_template('Report_Template.html')
 
-def create_report(model, output_filepath=path/'./Pynite Report.pdf', **kwargs):
+def create_report(model: FEModel3D, output_filepath:Path=path/'./Pynite Report.pdf', **kwargs):
     """Creates a pdf report for a given finite element model.
 
     :param model: The model to generate the report for.
     :type model: ``FEModel3D``
     :param output_filepath: The filepath to send the report to. Defaults to 'Pynite Report.pdf' in your ``PYTHONPATH``
     :type output_filepath: ``str``, optional
-    :param \**kwargs: See below for a list of valid arguments.
+    :param \\**kwargs: See below for a list of valid arguments.
     :Keyword Arguments:
         * *node_table* (``bool``) -- Set to ``True`` if you want node data included in the report. Defaults to ``True``.
         * *member_table* (``bool``) -- Set to ``True`` if you want member data included in the report. Defaults to ``True``.

--- a/Pynite/ShearWall.py
+++ b/Pynite/ShearWall.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
 if TYPE_CHECKING:
-    from typing import List, Dict
+    from typing import List, Dict, Tuple
     from Pynite.Quad3D import Quad3D
     import matplotlib.figure
 

--- a/Pynite/ShearWall.py
+++ b/Pynite/ShearWall.py
@@ -1,6 +1,8 @@
+from __future__ import annotations # Allows more recent type hints features
 from math import isclose
 from numpy import average
 import io
+from typing import TYPE_CHECKING
 
 from Pynite.FEModel3D import FEModel3D
 from prettytable import PrettyTable
@@ -8,83 +10,88 @@ from prettytable import PrettyTable
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
+if TYPE_CHECKING:
+    from typing import List, Dict
+    from Pynite.Quad3D import Quad3D
+    import matplotlib.figure
+
 class ShearWall():
     """Creates a new shear wall model that allows for modeling of complex shear walls. Shear wall models are 2D (aside from flanges) standalone models. You can add openings and flanges (wall returns). Diaphragm levels can be defined in order to apply shear forces along the length of the wall. Diaphgrams can be full or partial length. Supports can be applied at any level in the shear wall. Supports can also be full or partial length. A `ky_mod` factor is built in to account for cracking. Shear walls can automatically detect shear wall piers and coupling beams, and sum internal forces in those components.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
 
-        self.model = FEModel3D()
-        self._L = None
-        self._H = None
-        self._t = None
-        self._ky_mod = 0.35
-        self._mesh_size = 1
-        self._openings = []
-        self._flanges = []
-        self._supports = []
-        self._stories = []
-        self._shears = []
-        self._axials = []
-        self._materials = []
-        self.piers = {}
-        self.coupling_beams = {}
+        self.model: FEModel3D = FEModel3D()
+        self._L: float | None = None
+        self._H: float | None = None
+        self._t: float | None = None
+        self._ky_mod: float = 0.35
+        self._mesh_size: float = 1
+        self._openings: List[List[str | float | None]] = []
+        self._flanges: List[List[str | float]] = []
+        self._supports: List[List[float]] = []
+        self._stories: List[List[str | float]] = []
+        self._shears: List[List[str | float]] = []
+        self._axials: List[List[str | float]] = []
+        self._materials: List[List[str | float]] = []
+        self.piers: Dict[str, Pier] = {}
+        self.coupling_beams: Dict[str, CouplingBeam] = {}
     
     @property
-    def L(self):
+    def L(self) -> float | None:
         return self._L
 
     @L.setter
-    def L(self, value):
+    def L(self, value: float) -> None:
         self._L = value
     
     @property
-    def H(self):
+    def H(self) -> float | None:
         return self._H
 
     @H.setter
-    def H(self, value):
+    def H(self, value: float) -> None:
         self._H = value
 
     @property
-    def mesh_size(self):
+    def mesh_size(self) -> float:
         return self._mesh_size
     
     @mesh_size.setter
-    def mesh_size(self, value):
+    def mesh_size(self, value: float) -> None:
         self._mesh_size = value
     
     @property
-    def ky_mod(self):
+    def ky_mod(self) -> float:
         return self._ky_mod
     
     @ky_mod.setter
-    def ky_mod(self, value):
+    def ky_mod(self, value: float) -> None:
         self._ky_mod = value
     
-    def add_load_combo(self, name, factors, combo_type='strength'):
+    def add_load_combo(self, name: str, factors: Dict[str, float], combo_type: str = 'strength') -> None:
         self.model.add_load_combo(name, factors, combo_type)
 
-    def add_material(self, name, E, G, nu, rho, t, x_start=None, x_end=None, y_start=None, y_end=None):
+    def add_material(self, name: str, E: float, G: float, nu: float, rho: float, t: float, x_start: float | None = None, x_end: float | None = None, y_start: float | None = None, y_end: float | None = None) -> None:
         if x_start is None: x_start = 0
         if x_end is None: x_end = self._L
         if y_start is None: y_start = 0
         if y_end is None: y_end = self._H
         self._materials.append([name, E, G, nu, rho, t, x_start, x_end, y_start, y_end])
 
-    def add_opening(self, name, x_start, y_start, width, height, tie=None):
+    def add_opening(self, name: str, x_start: float, y_start: float, width: float, height: float, tie: float | None = None) -> None:
         self._openings.append([name, x_start, y_start, width, height, None])
     
-    def add_flange(self, thickness, width, x, y_start, y_end, material, side):
+    def add_flange(self, thickness: float, width: float, x: float, y_start: float, y_end: float, material: str, side: str) -> None:
         self._flanges.append([thickness, width, x, y_start, y_end, material, side])
     
-    def add_support(self, elevation=None, x_start=None, x_end=None):
+    def add_support(self, elevation: float | None = None, x_start: float | None = None, x_end: float | None = None) -> None:
         if elevation is None: elevation = 0
         if x_start is None: x_start = 0
         if x_end is None: x_end = self._L
         self._supports.append([elevation, x_start, x_end])
         
-    def add_story(self, story_name, elevation, x_start=None, x_end=None):
+    def add_story(self, story_name: str, elevation: float, x_start: float | None = None, x_end: float | None = None) -> None:
 
         # Validate input
         if elevation is None: elevation = self._H
@@ -100,13 +107,13 @@ class ShearWall():
         # Add a 100 kip story shear to the model to use when calculating the story's stiffness
         self.add_shear(story_name, 100, case=story_name)
 
-    def add_shear(self, story_name, force, case='Case 1'):
+    def add_shear(self, story_name: str, force: float, case: str = 'Case 1') -> None:
         self._shears.append([story_name, force, case])
     
-    def add_axial(self, story_name, force, case='Case 1'):
+    def add_axial(self, story_name: str, force: float, case: str = 'Case 1') -> None:
         self._axials.append([story_name, force, case])
 
-    def generate(self):
+    def generate(self) -> None:
 
         # Add materials to the model
         for material in self._materials:
@@ -114,8 +121,8 @@ class ShearWall():
             self.model.add_material(name, E, G, nu, rho)
         
         # Identify mesh control points
-        x_control = [0, self._L]
-        y_control = [0, self._H]
+        x_control: List[float] = [0, self._L]
+        y_control: List[float] = [0, self._H]
 
         for material in self._materials:
             x_control.append(material[6])
@@ -123,7 +130,7 @@ class ShearWall():
             y_control.append(material[8])
             y_control.append(material[9])
 
-        z_control = [0]
+        z_control: List[float] = [0]
         for flg in self._flanges:
             if flg[6] == 'NS': z_control.append(flg[1])
             else: z_control.append(-flg[1])
@@ -275,14 +282,14 @@ class ShearWall():
         self._identify_coupling_beams()
 
 
-    def _identify_piers(self):
+    def _identify_piers(self) -> None:
         
         # Reset all piers in the wall
         self.piers = {}
 
         # Create a list of x and y coordinates that represent the edges of the wall
-        x_vals = [0, self._L]
-        y_vals = [0, self._H]
+        x_vals: List[float] = [0, self._L]
+        y_vals: List[float] = [0, self._H]
 
         # Add the edges of the openings to the lists
         for opng in self._openings:
@@ -296,7 +303,7 @@ class ShearWall():
         y_vals = sorted(y_vals)
 
         # Remove duplicate (or near duplicate) values
-        unique_list = []
+        unique_list: List[float] = []
         for i in range(len(x_vals) - 1):
             # Only keep the value at `i` if it's not a duplicate or near duplicate of the next value
             if not isclose(x_vals[i], x_vals[i+1]):
@@ -322,7 +329,7 @@ class ShearWall():
             self.piers['P' + str(i+1)] = Pier('P' + str(i+1), x, y, width, height)
 
         # Divide the strip piers further into rectanglular piers using the top and bottom of each opening as pier boundaries
-        new_piers = {}
+        new_piers: Dict[str, Pier] = {}
         pier_count = 1
         for pier in self.piers.values():
             for i in range(len(y_vals) - 1):
@@ -335,7 +342,7 @@ class ShearWall():
         self.piers = new_piers
 
         # Delete any piers that fall within an opening
-        delete_list = []
+        delete_list: List[str] = []
         for pier in self.piers.values():
            # Check if this pier is inside any of the openings
            for opng in self._openings:
@@ -411,7 +418,7 @@ class ShearWall():
                     break
 
         # Generate a list of new keys in ascending order
-        new_keys = [f'P{i+1}' for i in range(len(self.piers))]
+        new_keys: List[str] = [f'P{i+1}' for i in range(len(self.piers))]
 
         # Replace the old dicionary with one that has updated keys
         self.piers = dict(zip(new_keys, self.piers.values()))
@@ -429,14 +436,14 @@ class ShearWall():
                     and round(Y_avg, 10) <= round (pier.y + pier.height, 10)):
                     pier.plates.append(plate)
     
-    def _identify_coupling_beams(self):
+    def _identify_coupling_beams(self) -> None:
         
         # Reset all coupling beams in the wall
         self.coupling_beams = {}
 
         # Create a list of x and y coordinates that represent the edges of the wall
-        x_vals = [0, self._L]
-        y_vals = [0, self._H]
+        x_vals: List[float] = [0, self._L]
+        y_vals: List[float] = [0, self._H]
 
         # Add the edges of the openings to the lists
         for opng in self._openings:
@@ -450,7 +457,7 @@ class ShearWall():
         y_vals = sorted(y_vals)
 
         # Remove duplicate (or near duplicate) values
-        unique_list = []
+        unique_list: List[float] = []
         for i in range(len(x_vals) - 1):
             # Only keep the value at `i` if it's not a duplicate or near duplicate of the next value
             if not isclose(x_vals[i], x_vals[i+1]):
@@ -476,7 +483,7 @@ class ShearWall():
             self.coupling_beams['B' + str(i+1)] = CouplingBeam('B' + str(i+1), x, y, length, height)
 
         # Divide the strips further into rectanglular beams using the left and right of each opening as beam boundaries
-        new_beams = {}
+        new_beams: Dict[str, CouplingBeam] = {}
         beam_count = 1
         for beam in self.coupling_beams.values():
             for i in range(len(x_vals) - 1):
@@ -489,7 +496,7 @@ class ShearWall():
         self.coupling_beams = new_beams
 
         # Delete any beams that fall within an opening
-        delete_list = []
+        delete_list: List[str] = []
         for beam in self.coupling_beams.values():
            
            # Check if this beam is inside any of the openings
@@ -576,7 +583,7 @@ class ShearWall():
             del self.coupling_beams[beam]
 
         # Generate a list of new keys in ascending order
-        new_keys = [f'B{i + 1}' for i in range(len(self.coupling_beams))]
+        new_keys: List[str] = [f'B{i + 1}' for i in range(len(self.coupling_beams))]
 
         # Replace the old dicionary with one that has updated keys
         self.coupling_beams = dict(zip(new_keys, self.coupling_beams.values()))
@@ -594,7 +601,7 @@ class ShearWall():
                     and round(Y_avg, 10) <= round (beam.y + beam.height, 10)):
                     beam.plates.append(plate)
 
-    def draw_piers(self, show=False):
+    def draw_piers(self, show: bool = False) -> None | matplotlib.figure.Figure:
         
         fig, ax = plt.subplots()
 
@@ -613,7 +620,7 @@ class ShearWall():
         if show == True: plt.show()
         else: return plt
     
-    def draw_coupling_beams(self, show=False):
+    def draw_coupling_beams(self, show: bool = False) -> None | matplotlib.figure.Figure:
         
         fig, ax = plt.subplots()
 
@@ -639,7 +646,7 @@ class ShearWall():
         if show == True: plt.show()
         else: return plt
 
-    def _add_rectangle(self, ax, x, y, w, h, name, color='white'):
+    def _add_rectangle(self, ax: matplotlib.axes.Axes, x: float, y: float, w: float, h: float, name: str, color: str = 'white') -> None:
         """Adds a rectangle to the pyplot
         """
 
@@ -654,7 +661,7 @@ class ShearWall():
         ax.set_xlim(0, max(ax.get_xlim()[1], x + w))
         ax.set_ylim(0, max(ax.get_ylim()[1], y + h))
     
-    def _sort_openings(self):
+    def _sort_openings(self) -> None:
 
         # Sort the openings based on y-coordinates
         n = len(self._openings)
@@ -670,7 +677,7 @@ class ShearWall():
                 if self._openings[j][1] > self._openings[j+1][1]:
                     self._openings[j], self._openings[j+1] = self._openings[j+1], self._openings[j]
 
-    def stiffness(self, story_name):
+    def stiffness(self, story_name: str) -> float:
 
         # TODO: Validate that the specified story exists in the shear wall
 
@@ -701,7 +708,7 @@ class ShearWall():
         # Return the story's stiffness:
         return V/(d_max*12)
 
-    def render(self, color_map='Txy', combo_name='Combo 1'):
+    def render(self, color_map: str = 'Txy', combo_name: str = 'Combo 1') -> None:
         
         from Pynite.Visualization import Renderer
         renderer = Renderer(self.model)
@@ -715,7 +722,7 @@ class ShearWall():
         renderer.labels = False
         renderer.render_model()
     
-    def screenshots(self, combo_name='Combo 1', dir_path='./'):
+    def screenshots(self, combo_name: str = 'Combo 1', dir_path: str = './') -> None:
 
         from Pynite.Rendering import Renderer
         
@@ -742,7 +749,7 @@ class ShearWall():
         pier_sketch = self.draw_piers(show=False)
         pier_sketch.savefig(dir_path + '/shear_wall_piers.png', format='png')
 
-    def print_piers(self, combo_name='Combo 1'):
+    def print_piers(self, combo_name: str = 'Combo 1') -> None:
         """Tabulates and prints pier results for the shear wall
         """
 
@@ -763,7 +770,7 @@ class ShearWall():
         print('+-------------------+')
         print(table)
     
-    def print_coupling_beams(self, combo_name='Combo 1'):
+    def print_coupling_beams(self, combo_name: str = 'Combo 1') -> None:
         """Tabulates and prints coupling beam results for the shear wall
         """
 
@@ -787,15 +794,15 @@ class ShearWall():
 #%%
 class Pier():
     
-    def __init__(self, name, x, y, width, height):
-        self.name = name
-        self.x = x  # The location of the left side of the pier
-        self.y = y  # The height of the bottom of the pier
-        self.width = width
-        self.height = height
-        self.plates = []
+    def __init__(self, name: str, x: float, y: float, width: float, height: float) -> None:
+        self.name: str = name
+        self.x: float = x  # The location of the left side of the pier
+        self.y: float = y  # The height of the bottom of the pier
+        self.width: float = width
+        self.height: float = height
+        self.plates: List[Quad3D] = []
     
-    def sum_forces(self, combo_name='Combo 1'):
+    def sum_forces(self, combo_name: str = 'Combo 1') -> Tuple[float, float, float, float]:
 
         # Initialize the forces in the plate
         P, M, V = 0, 0, 0
@@ -837,15 +844,15 @@ class Pier():
 #%%
 class CouplingBeam():
     
-    def __init__(self, name, x, y, length, height):
-        self.name = name
-        self.x = x  # The location of the left side of the coupling beam
-        self.y = y  # The height to the bottom of the coupling beam
-        self.length = length
-        self.height = height
-        self.plates = []
+    def __init__(self, name: str, x: float, y: float, length: float, height: float) -> None:
+        self.name: str = name
+        self.x: float = x  # The location of the left side of the coupling beam
+        self.y: float = y  # The height to the bottom of the coupling beam
+        self.length: float = length
+        self.height: float = height
+        self.plates: List[Quad3D] = []
     
-    def sum_forces(self, combo_name='Combo 1'):
+    def sum_forces(self, combo_name: str = 'Combo 1') -> Tuple[float, float, float, float]:
 
         # Initialize plate forces to zero
         P, M, V = 0, 0, 0

--- a/Pynite/Spring3D.py
+++ b/Pynite/Spring3D.py
@@ -1,9 +1,17 @@
 # %%
+from __future__ import annotations # Allows more recent type hints features
 from numpy import zeros, array, add, subtract, matmul, insert, cross, divide
 from numpy.linalg import inv
 from math import isclose
 import Pynite.FixedEndReactions
 from Pynite.LoadCombo import LoadCombo
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, Optional
+    from numpy import float64
+    from numpy.typing import NDArray
+    from Pynite.Node3D import Node3D
 
 # %%
 class Spring3D():
@@ -14,27 +22,28 @@ class Spring3D():
     __plt = None
 
 #%%
-    def __init__(self, name, i_node, j_node, ks, LoadCombos={'Combo 1':LoadCombo('Combo 1', factors={'Case 1':1.0})},
-                 tension_only=False, comp_only=False):
+    def __init__(self, name: str, i_node: Node3D, j_node: Node3D, ks: float, 
+                 LoadCombos: Dict[str, LoadCombo] = {'Combo 1': LoadCombo('Combo 1', factors={'Case 1': 1.0})},
+                 tension_only: bool = False, comp_only: bool = False) -> None:
         '''
         Initializes a new spring.
         '''
-        self.name = name      # A unique name for the spring given by the user
-        self.ID = None        # Unique index number for the spring assigned by the program
-        self.i_node = i_node  # The spring's i-node
-        self.j_node = j_node  # The spring's j-node
-        self.ks = ks          # The spring constant (force/displacement)
-        self.load_combos = LoadCombos # The dictionary of load combinations in the model this spring belongs to
-        self.tension_only = tension_only # Indicates whether the spring is tension-only
-        self.comp_only = comp_only # Indicates whether the spring is compression-only
+        self.name: str = name      # A unique name for the spring given by the user
+        self.ID: Optional[int] = None        # Unique index number for the spring assigned by the program
+        self.i_node: Node3D = i_node  # The spring's i-node
+        self.j_node: Node3D = j_node  # The spring's j-node
+        self.ks: float = ks          # The spring constant (force/displacement)
+        self.load_combos: Dict[str, LoadCombo] = LoadCombos # The dictionary of load combinations in the model this spring belongs to
+        self.tension_only: bool = tension_only # Indicates whether the spring is tension-only
+        self.comp_only: bool = comp_only # Indicates whether the spring is compression-only
 
         # Springs need to track whether they are active or not for any given load combination.
         # They may become inactive for a load combination during a tension/compression-only
         # analysis. This dictionary will be used when the model is solved.
-        self.active = {} # Key = load combo name, Value = True or False
+        self.active: Dict[str, bool] = {} # Key = load combo name, Value = True or False
 
 #%%
-    def L(self):
+    def L(self) -> float:
         '''
         Returns the length of the spring.
         '''
@@ -43,7 +52,7 @@ class Spring3D():
         return self.i_node.distance(self.j_node)
 
 #%%
-    def k(self):
+    def k(self) -> NDArray[float64]:
         '''
         Returns the local stiffness matrix for the spring.
         '''
@@ -70,7 +79,7 @@ class Spring3D():
         return k
 
 #%%   
-    def f(self, combo_name='Combo 1'):
+    def f(self, combo_name: str = 'Combo 1') -> NDArray[float64]:
         '''
         Returns the spring's local end force vector for the given load combination.
 
@@ -84,7 +93,7 @@ class Spring3D():
         return matmul(self.k(), self.d(combo_name))
 
 #%%
-    def d(self, combo_name='Combo 1'):
+    def d(self, combo_name: str = 'Combo 1') -> NDArray[float64]:
         '''
         Returns the spring's local displacement vector.
 
@@ -98,7 +107,7 @@ class Spring3D():
         return matmul(self.T(), self.D(combo_name))
         
 #%%
-    def T(self):
+    def T(self) -> NDArray[float64]:
         '''
         Returns the transformation matrix for the spring.
         '''
@@ -175,7 +184,7 @@ class Spring3D():
         return transMatrix
 
 #%%
-    def K(self):
+    def K(self) -> NDArray[float64]:
         '''
         Spring global stiffness matrix
         '''
@@ -184,7 +193,7 @@ class Spring3D():
         return matmul(matmul(inv(self.T()), self.k()), self.T())
 
 #%%
-    def F(self, combo_name='Combo 1'):
+    def F(self, combo_name: str = 'Combo 1') -> NDArray[float64]:
         '''
         Returns the spring's global end force vector for the given load combination.
         '''
@@ -193,7 +202,7 @@ class Spring3D():
         return matmul(inv(self.T()), self.f(combo_name))
 
 #%%
-    def D(self, combo_name='Combo 1'):
+    def D(self, combo_name: str = 'Combo 1') -> NDArray[float64]:
         '''
         Returns the spring's global displacement vector.
 
@@ -229,7 +238,7 @@ class Spring3D():
         return D
 
 #%%
-    def axial(self, combo_name='Combo 1'):
+    def axial(self, combo_name: str = 'Combo 1') -> float:
         '''
         Returns the axial force in the spring.
         

--- a/Pynite/Tri3D.py
+++ b/Pynite/Tri3D.py
@@ -1,11 +1,20 @@
-from numpy import zeros, array, matmul, cross, add
+from __future__ import annotations # Allows more recent type hints features
+from typing import List, TYPE_CHECKING
+
+from numpy import zeros, array, matmul, cross, add, float64
 from numpy.linalg import inv, norm, det
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+    from Pynite.Node3D import Node3D
+    from Pynite.FEModel3D import FEModel3D
 
 #%%
 class Tri3D():
 
-    def __init__(self, name, i_node, j_node, k_node, t, material_name, model, kx_mod=1.0,
-                 ky_mod=1.0):
+    def __init__(self, name: str, i_node: Node3D, j_node: Node3D, k_node: Node3D, 
+                 t: float, material_name: str, model: FEModel3D, kx_mod: float = 1.0,
+                 ky_mod: float = 1.0) -> None:
         """
         A rectangular plate element
 
@@ -53,8 +62,8 @@ class Tri3D():
 
         # Get material properties for the plate from the model
         try:
-            self.E = self.model.Materials[material_name].E
-            self.nu = self.model.Materials[material_name].nu
+            self.E = self.model.materials[material_name].E
+            self.nu = self.model.materials[material_name].nu
         except:
             raise KeyError('Please define the material ' + str(material_name) + ' before assigning it to plates.')
     
@@ -64,13 +73,13 @@ class Tri3D():
         """
         return self.i_node.distance(self.j_node)
 
-    def height(self):
+    def height(self) -> float:
         """
         Returns the height of the plate along its local y-axis
         """
         return self.i_node.distance(self.n_node)
     
-    def Dm(self):
+    def Dm(self) -> NDArray[float64]:
         """
         Returns the plane stress constitutive matrix for orthotropic materials [Dm]
         """
@@ -96,7 +105,7 @@ class Tri3D():
         # Return the constitutive matrix [Dm]
         return Dm
 
-    def Db(self):
+    def Db(self) -> NDArray[float64]:
         """
         Returns the bending constitutive matrix for orthotropic materials [Db]
         """
@@ -117,7 +126,7 @@ class Tri3D():
         # Return the constitutive matrix [Db]
         return Db
 
-    def J(self, r, s):
+    def J(self, r: float, s: float) -> NDArray[float64]:
         '''
         Returns the Jacobian matrix for the element
         '''
@@ -146,13 +155,13 @@ class Tri3D():
         
         return B_m
     
-    def k(self):
+    def k(self) -> NDArray[float64]:
         """
         returns the plate's local stiffness matrix
         """
         return add(self.k_b(), self.k_m())
     
-    def k_m(self):
+    def k_m(self) -> NDArray[float64]:
         '''
         Returns the local stiffness matrix for membrane (in-plane) stresses.
 
@@ -210,7 +219,7 @@ class Tri3D():
         
         return k_exp
     
-    def k_b(self):
+    def k_b(self) -> NDArray[float64]:
         """
         Returns the local stiffness matrix for bending
         """
@@ -297,7 +306,7 @@ class Tri3D():
         # Return the local stiffness matrix
         return k_exp
 
-    def f(self, combo_name='Combo 1'):
+    def f(self, combo_name='Combo 1') -> NDArray[float64]:
         """
         Returns the plate's local end force vector
         """
@@ -319,7 +328,7 @@ class Tri3D():
         fer = zeros((12, 1))
 
         # Get the requested load combination
-        combo = self.model.LoadCombos[combo_name]
+        combo = self.model.load_combos[combo_name]
 
         # Initialize the element's surface pressure to zero
         p = 0
@@ -376,7 +385,7 @@ class Tri3D():
 
         return fer_exp
         
-    def d(self, combo_name='Combo 1'):
+    def d(self, combo_name: str='Combo 1') -> NDArray[float64]:
        """
        Returns the plate's local displacement vector
        """
@@ -384,7 +393,7 @@ class Tri3D():
        # Calculate and return the local displacement vector
        return matmul(self.T(), self.D(combo_name))
 
-    def F(self, combo_name='Combo 1'):
+    def F(self, combo_name:str ='Combo 1') -> NDArray[float64]:
         """
         Returns the plate's global nodal force vector
         """
@@ -392,7 +401,7 @@ class Tri3D():
         # Calculate and return the global force vector
         return matmul(inv(self.T()), self.f(combo_name))
 
-    def D(self, combo_name='Combo 1'):
+    def D(self, combo_name:str ='Combo 1') -> NDArray[float64]:
         """
         Returns the plate's global displacement vector for the given load combination.
         """
@@ -432,7 +441,7 @@ class Tri3D():
         # Return the global displacement vector
         return D
  
-    def T(self):
+    def T(self) -> NDArray[float64]:
         """
         Returns the plate's transformation matrix
         """
@@ -483,7 +492,7 @@ class Tri3D():
         
         return transMatrix
 
-    def K(self):
+    def K(self) -> NDArray[float64]:
         """
         Returns the plate's global stiffness matrix
         """
@@ -491,7 +500,7 @@ class Tri3D():
         # Calculate and return the stiffness matrix in global coordinates
         return matmul(matmul(inv(self.T()), self.k()), self.T())
 
-    def FER(self, combo_name='Combo 1'):
+    def FER(self, combo_name='Combo 1') -> NDArray[float64]:
         """
         Returns the global fixed end reaction vector.
 
@@ -505,7 +514,7 @@ class Tri3D():
         # Calculate and return the fixed end reaction vector
         return matmul(inv(self.T()), self.fer(combo_name))
 
-    def _C(self):
+    def _C(self) -> NDArray[float64]:
         """
         Returns the plate's displacement coefficient matrix [C]
         """
@@ -540,7 +549,7 @@ class Tri3D():
         # Return the coefficient matrix
         return C
 
-    def _Q(self, x, y):
+    def _Q(self, x:float, y:float) -> NDArray[float64]:
         """
         Calculates and returns the plate curvature coefficient matrix [Q] at a given point (x, y)
         in the plate's local system.
@@ -554,7 +563,7 @@ class Tri3D():
         # Return the [Q] coefficient matrix
         return Q
 
-    def _a(self, combo_name='Combo 1'):
+    def _a(self, combo_name:str ='Combo 1') -> NDArray[float64]:
         """
         Returns the vector of plate bending constants for the displacement function.
 
@@ -571,7 +580,7 @@ class Tri3D():
         # Return the plate bending constants
         return inv(self._C()) @ d
 
-    def moment(self, x, y, combo_name='Combo 1'):
+    def moment(self, x:float, y:float, combo_name:str ='Combo 1') -> NDArray[float64]:
         """
         Returns the internal moments (Mx, My, and Mxy) at any point (x, y) in the plate's local
         coordinate system
@@ -592,7 +601,7 @@ class Tri3D():
         # Pynite's quadrilateral elements.
         return -self.Db() @ self._Q(x, y) @ self._a(combo_name)
  
-    def shear(self, x, y, combo_name='Combo 1'):
+    def shear(self, x:float, y:float, combo_name:str='Combo 1') -> NDArray[float64]:
         """
         Returns the internal shears (Qx and Qy) at any point (x, y) in the plate's local
         coordinate system
@@ -637,7 +646,7 @@ class Tri3D():
         return array([[Qx], 
                        [Qy]])
 
-    def membrane(self, x, y, combo_name='Combo 1'):
+    def membrane(self, x:float, y:float, combo_name:str='Combo 1') -> NDArray[float64]:
         
         # Convert the (x, y) coordinates to (r, x) coordinates
         r = -1 + 2*x/self.width()

--- a/Pynite/Visualization.py
+++ b/Pynite/Visualization.py
@@ -1,4 +1,4 @@
-
+from __future__ import annotations # Allows more recent type hints features
 from json import load
 import warnings
 
@@ -864,7 +864,7 @@ class VisPtLoad():
     Creates a point load for the viewer
     '''
     
-    def __init__(self, position, direction, length, label_text=None, annotation_size=5, color=None):
+    def __init__(self, position, direction, length, label_text: str | None = None, annotation_size=5, color: str | None = None):
         '''
         Constructor.
       
@@ -878,7 +878,7 @@ class VisPtLoad():
           The length of the load arrow.
         tip_length : number
           The height of the arrow head.
-        label_text : string
+        label_text : string | None
           Text that will show up at the tail of the arrow. If set to 'None' no text will be displayed.
         '''
       


### PR DESCRIPTION
This add type hints to almost all class and method functions throughout library. I tried to scope new type related imports under the `if TYPE_CHECKING:` flag to minimize actual runtime performance hits from additional imports.

There were a few places where the types were a little ambiguous (mostly on the internal methods), so the types might be narrowed too much. For example, the argument x might permit a list of floats inl ieu of just a single float. 
 
Also, I Left type errors that show up in the editor after defining types on things largely untouched to keep scope of this PR strictly to adding type hints to the code. Future PRs can address these kind of warnings. These warnings were good to be warned about and should probably be fixed at some point to prevent errors popping up later.

I also largely left the imports as you have them (i.e. didn't remove unused imports), but I did try to sort them into PEP8 style order (standard lib -> 3rd party -> this package).

All tests are still passing.