### PR TITLE
Add post-update callback to Renderer for pv.Plotter (self.plotter) customization

### DIFF
--- a/Pynite/Rendering.py
+++ b/Pynite/Rendering.py
@@ -48,7 +48,10 @@ class Renderer:
         self._scalar_bar_text_size: int = 24
         self.theme: str = 'default'
 
-        # List to hold user-defined functions to be called after internal update
+        # Callback list for post-update customization:
+        # This is added because `self.update()` clears the plotter, removing user self.plotter configurations.
+        # Functions in this list run after Pynite adds actors, allowing further PyVista customizations 
+        # (e.g., grid, axes) before render. Each func in this list must accept a `pyvista.Plotter` argument.
         self.post_update_callbacks: List[Callable[[pv.Plotter], None]] = []
 
         self.plotter: pv.Plotter = pv.Plotter()
@@ -312,7 +315,8 @@ class Renderer:
         # if self._scalar_bar == False:
         #     self.plotter.scalar_bar.VisibilityOff()
 
-        # Execute user-defined post-update callbacks (for customizing self.plotter by the user)
+        # Execute user-defined post-update callbacks.
+        # Allows plotter customization after internal Pynite updates. See __init__.
         if hasattr(self, 'post_update_callbacks') and self.post_update_callbacks:
             for func in self.post_update_callbacks:
                 if callable(func):
@@ -329,7 +333,6 @@ class Renderer:
             self.plotter.reset_camera()
 
 
-    
     def plot_node(self, node: Node3D, color: str = 'grey') -> None:
         """Adds a node to the plotter
 


### PR DESCRIPTION
**Problem:**
Users attempting to customize the PyVista `plotter` instance within `Pynite.Rendering.Renderer` (e.g., adding grids or origin axes using `plotter.show_grid()`) before calling `render_model()` find their additions are removed. This occurs because the internal `Renderer.update()` method clears the plotter (using self.plotter.clear()) before adding Pynite's standard visualization elements.

**Solution:**
This change introduces a simple callback mechanism:
1.  A new list attribute, `post_update_callbacks: List[Callable[[pv.Plotter], None]]`, is added to the `Renderer` class during initialization. The type hint clearly indicates that functions added to this list must accept a `pyvista.Plotter` object as their sole argument.
2.  At the end of the `Renderer.update()` method, after Pynite has added its own actors, the code now iterates through any functions stored in `post_update_callbacks`.
3.  Each user-provided function is called and passed the `renderer.plotter` instance, allowing direct and persistent modification using PyVista methods just before the plot is shown.
4.  Basic error handling (`try...except` and `callable` check) is included around the callback execution.

**Benefits:**
*   Provides a clean and explicit hook for users to customize the plot *after* Pynite's internal setup is complete but *before* the plot is shown.
*   Keeps the Pynite `Renderer` code changes minimal and focused.
*   Maintains backward compatibility.
*   Enables users to leverage the full power of PyVista for annotations, different actors, camera manipulation, etc., within the context of the Pynite visualization.

**Example Usage:**
```python
# Ensure PyVista is imported for type hints and methods
import pyvista as pv
from Pynite.Rendering import Renderer # Assuming modified version

# Define the callback function accepting the plotter argument
def add_my_extras(plotter: pv.Plotter):
    plotter.show_grid(color='grey')
    plotter.add_axes_at_origin()

# --- Inside user's script ---
model = ... # Your analyzed Pynite model
renderer = Renderer(model)
# ... other standard renderer settings ...

# Add the custom function to the callback list
renderer.post_update_callbacks.append(add_my_extras)

# Pass reset_camera=False if camera was set manually in add_my_extras
renderer.render_model(reset_camera=False)