### PR TITLE
test: added continuous beam test to check max moment results

### DIFF
--- a/Testing/test_continuous_beam.py
+++ b/Testing/test_continuous_beam.py
@@ -1,0 +1,47 @@
+import unittest
+from Pynite import FEModel3D
+import math
+import sys
+from io import StringIO
+
+class Test_Continuous_Beam(unittest.TestCase):
+    ''' Tests of analyzing 2D frames. '''
+
+    def setUp(self):
+        # Suppress printed output temporarily
+        sys.stdout = StringIO()
+
+    def tearDown(self):
+        # Reset the print function to normal
+        sys.stdout = sys.__stdout__
+
+
+    def create_model(self):
+        continuous_beam = FEModel3D()
+
+        continuous_beam.add_node('N1', 0, 0, 0)
+        continuous_beam.add_node('N2', 10*12, 0, 0)
+        continuous_beam.add_node('N3', 20*12, 0, 0)
+
+        continuous_beam.add_material("Material", 29000, 7700, 0.3, 0.001)
+        continuous_beam.add_section("Section", A=20, Iy=100, Iz=150, J=250)
+
+        continuous_beam.add_member('M1', 'N1', 'N3', "Material", "Section")
+
+        continuous_beam.def_support('N1', True, True, True, True, True, False)  # Constrained for torsion at 'N1'
+        continuous_beam.def_support('N2', False, True, False, False, False, False) # Not constrained for torsion at 'N2'
+        continuous_beam.def_support('N3', False, True, False, False, False, False) # Same for 'N3'
+
+        continuous_beam.add_member_dist_load("M1", "Fy", -10, -10, 0, 20*12, case="D")
+
+        continuous_beam.add_load_combo('1.0D', {'D':1.0})
+        continuous_beam.analyze()
+
+        return continuous_beam
+        
+
+    def test_continuous_beam_moments(self):
+       model = self.create_model()
+       member = model.members['M1']
+       assert math.isclose(member.max_moment("Mz", "1.0D"), 18000.0)
+       assert math.isclose(max(member.moment_array("Mz", 10000, "1.0D")[1]), 18000.00)


### PR DESCRIPTION
Quickly implemented test to validate the results of the `FEModel3D.moment_array` method.

Will add additional tests for the other array methods which will be used to validate that `max(model.something_array(...)[1]) == model.max_something(...)` and `min(model.something_array(...)[1]) == model.min_something(...)`.

These tests are expected to fail on the current version of PyNite at the time this pull request was opened.