### PR TITLE
feat: implement dynamic __version__

### DIFF
--- a/Pynite/__init__.py
+++ b/Pynite/__init__.py
@@ -1,3 +1,12 @@
 # Select libraries that will be imported into Pynite for the user
 from Pynite.FEModel3D import FEModel3D
 from Pynite.ShearWall import ShearWall
+import Pynite
+
+from pip._vendor import pkg_resources
+
+def get_version(package):
+    package = package.lower()
+    return next((p.version for p in pkg_resources.working_set if p.project_name.lower() == package), "No match")
+
+__version__= get_version("PyniteFEA")


### PR DESCRIPTION
Version is retrieved dynamically from the package after it is built by setup.py. This allows users to access the version of Pynite they have installed without @JWock82 having to manually update the version number in `__init__.py` whenever a new release is made.

Closes #273 

In the long-term, I recommend moving away from setup.py to pyproject.toml where the version and description of the package can be dynamically retrieved from the `__init__.py` file (making the `__init__.py` file the source of truth and the package being built according to those values). 

However, this is a quick fix that will allow users to easily check their Pynite version to aid in the diagnosis of potential incorrect values.