### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setuptools.setup(
         'derivations': ['jupyterlab', 'sympy']
     },
     include_package_data = True,
-    python_requires = '>=3.7',
+    python_requires = '>=3.8',
 )


### PR DESCRIPTION
This allows the project to leverage Python features introduce in Python 3.8.
Python 3.7 reached its [end-of-life on June 27, 2023](https://peps.python.org/pep-0537/).

Resolves #290
