### PR TITLE
Check unused imports via ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  prek:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.9
+    hooks:
+      - id: ruff-check
+        args: [--fix, --show-fixes]

--- a/Examples/Circular Bin with Conical Hopper.py
+++ b/Examples/Circular Bin with Conical Hopper.py
@@ -1,6 +1,4 @@
-from math import pi
 from Pynite.FEModel3D import FEModel3D
-from Pynite.Mesh import FrustrumMesh, CylinderMesh
 
 t = 0.25/12
 E = 29000*1000*12**2

--- a/Examples/Pushover Analysis.py
+++ b/Examples/Pushover Analysis.py
@@ -1,4 +1,3 @@
-from math import isclose
 
 from Pynite.FEModel3D import FEModel3D
 

--- a/Examples/Simple Beam - Factored Envelope.py
+++ b/Examples/Simple Beam - Factored Envelope.py
@@ -2,11 +2,8 @@
 
 # Import `FEModel3D` from `Pynite`
 from Pynite import FEModel3D
-from matplotlib import pyplot as plt
-import numpy as np
 
 # Import 'Visualization' for rendering the model
-from Pynite import Visualization
 
 # Create a new finite element model
 simple_beam = FEModel3D()

--- a/Examples/Simple Beam - Point Load.py
+++ b/Examples/Simple Beam - Point Load.py
@@ -5,7 +5,6 @@
 from Pynite import FEModel3D
 
 # Import 'Visualization' for rendering the model
-from Pynite import Visualization
 
 # Create a new finite element model
 simple_beam = FEModel3D()

--- a/Pynite/Analysis.py
+++ b/Pynite/Analysis.py
@@ -4,7 +4,7 @@ from math import isclose
 
 import warnings
 
-from numpy import array, atleast_2d, zeros, subtract, matmul, divide, seterr, nanmax, asarray, isfinite
+from numpy import array, zeros, subtract, matmul, asarray, isfinite
 from numpy.linalg import solve, norm, LinAlgError
 
 from Pynite.LoadCombo import LoadCombo
@@ -1495,7 +1495,8 @@ def _partition_D(model: FEModel3D) -> Tuple[List[int], List[int], NDArray[float6
             D2_indices.append(node.ID*6 + 5)
             D2.append(0.0)
 
-    # Legacy code on the next line. I will leave it here until the line that follows has been proven over time.
+    # Legacy code on the next lines. I will leave it here until the line that follows has been proven over time.
+    # from numpy import atleast_2d
     # D2 = atleast_2d(D2)
 
     # Convert D2 from a list to a matrix

--- a/Pynite/FEModel3D.py
+++ b/Pynite/FEModel3D.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-from numpy.linalg import solve
 import scipy as sp
 
 from Pynite.Node3D import Node3D
@@ -2366,7 +2365,7 @@ class FEModel3D():
 
         # Import `scipy` features if the sparse solver is being used
         if sparse == True:
-            from scipy.sparse.linalg import spsolve
+            from scipy.sparse.linalg import spsolve  # noqa: F401
 
         # Prepare the model for analysis
         Analysis._prepare_model(self)
@@ -2432,7 +2431,7 @@ class FEModel3D():
 
         # Import `scipy` features if the sparse solver is being used
         if sparse == True:
-            from scipy.sparse.linalg import spsolve
+            from scipy.sparse.linalg import spsolve  # noqa: F401
 
         # Prepare the model for analysis
         Analysis._prepare_model(self)

--- a/Pynite/Node3D.py
+++ b/Pynite/Node3D.py
@@ -6,18 +6,16 @@ Created on Thu Nov  2 18:04:56 2017
 """
 from __future__ import annotations  # Allows more recent type hints features
 # %%
-from numpy import array, zeros
+from numpy import zeros
 
 from typing import List, Tuple, Dict, Optional,TYPE_CHECKING
 if TYPE_CHECKING:
 
-    from typing import Dict, List, Tuple, Optional, Any, Literal
+    from typing import Dict, List, Tuple, Optional
 
-    from numpy import float64
     from numpy.typing import NDArray
 
     from Pynite.FEModel3D import FEModel3D
-    from Pynite.LoadCombo import LoadCombo
 
 
 class Node3D():

--- a/Pynite/PhysMember.py
+++ b/Pynite/PhysMember.py
@@ -6,13 +6,12 @@ if TYPE_CHECKING:
 
     from Pynite.Node3D import Node3D
     from Pynite.FEModel3D import FEModel3D
-    import numpy.typing as npt
     from numpy import float64
     from numpy.typing import NDArray
 
-from numpy import array, dot, linspace, hstack, empty, maximum, minimum
+from numpy import array, linspace, hstack, empty, maximum, minimum
 from numpy.linalg import norm
-from math import isclose, acos
+from math import isclose
 
 class PhysMember(Member3D):
     """

--- a/Pynite/Rendering.py
+++ b/Pynite/Rendering.py
@@ -6,11 +6,9 @@ Docstrings follow reStructuredText field-list format for Sphinx autodoc.
 """
 
 from __future__ import annotations # Allows more recent type hints features
-from json import load
 import warnings
-from typing import TYPE_CHECKING, Callable, List, Any, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Callable, List, Optional, Union, Tuple
 
-from IPython.display import Image
 import numpy as np
 import pyvista as pv
 import math

--- a/Pynite/ShearWall.py
+++ b/Pynite/ShearWall.py
@@ -1,7 +1,5 @@
 from __future__ import annotations # Allows more recent type hints features
 from math import isclose
-from numpy import average
-import io
 import os
 from typing import TYPE_CHECKING, Literal
 

--- a/Pynite/Spring3D.py
+++ b/Pynite/Spring3D.py
@@ -1,9 +1,8 @@
 # %%
 from __future__ import annotations # Allows more recent type hints features
-from numpy import zeros, array, add, subtract, matmul, insert, cross, divide
+from numpy import zeros, array, matmul, cross, divide
 from numpy.linalg import inv
 from math import isclose
-import Pynite.FixedEndReactions
 from Pynite.LoadCombo import LoadCombo
 from typing import TYPE_CHECKING
 

--- a/Pynite/Tri3D.py
+++ b/Pynite/Tri3D.py
@@ -1,5 +1,5 @@
 from __future__ import annotations # Allows more recent type hints features
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from numpy import zeros, array, matmul, cross, add, float64
 from numpy.linalg import inv, norm, det

--- a/Pynite/__init__.py
+++ b/Pynite/__init__.py
@@ -5,6 +5,14 @@ import Pynite
 
 from importlib.metadata import version, PackageNotFoundError
 
+
+__all__ = (
+    "FEModel3D",
+    "ShearWall",
+    "Pynite",
+    "__version__",
+)
+
 try:
     __version__ = version("PyniteFEA")
 except PackageNotFoundError:

--- a/Testing/test_2D_frames.py
+++ b/Testing/test_2D_frames.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_TC_analysis.py
+++ b/Testing/test_TC_analysis.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_Visualization.py
+++ b/Testing/test_Visualization.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import vtk
 from io import BytesIO

--- a/Testing/test_end_releases.py
+++ b/Testing/test_end_releases.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_loads.py
+++ b/Testing/test_loads.py
@@ -6,7 +6,7 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 """
 
 import unittest
-from Pynite import FEModel3D, Section
+from Pynite import FEModel3D
 import sys
 from io import StringIO
 

--- a/Testing/test_meshes.py
+++ b/Testing/test_meshes.py
@@ -1,5 +1,4 @@
 from Pynite import FEModel3D
-from Pynite.Rendering import Renderer
 from math import isclose
 
 

--- a/Testing/test_pushover.py
+++ b/Testing/test_pushover.py
@@ -2,7 +2,6 @@ from math import isclose
 
 import matplotlib
 matplotlib.use('TkAgg')
-import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 
 from Pynite.FEModel3D import FEModel3D  # noqa: E402
@@ -68,6 +67,7 @@ def test_plastic_beam():
     )
 
     # Plot the two traces on the same graph for each combo
+    # import matplotlib.pyplot as plt
     # for combo_name, trace_data in plastic_beam._pushover_traces.items():
     #     steps = list(range(len(trace_data['M_ba'])))
     #     plt.figure()

--- a/Testing/test_reanalysis.py
+++ b/Testing/test_reanalysis.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_sloped_beam.py
+++ b/Testing/test_sloped_beam.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_support_settlement.py
+++ b/Testing/test_support_settlement.py
@@ -12,7 +12,6 @@ Example 13.14
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_torsion.py
+++ b/Testing/test_torsion.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 from Pynite import FEModel3D
-import math
 import sys
 from io import StringIO
 

--- a/Testing/test_unstable_structure.py
+++ b/Testing/test_unstable_structure.py
@@ -7,7 +7,6 @@ Copyright (c) 2020 D. Craig Brinck, SE; tamalone1
 
 import unittest
 
-from numpy import True_
 from Pynite import FEModel3D
 import sys
 from io import StringIO

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+target-version = "py311"
+extend-exclude = [
+    "*.ipynb",
+    ".Archived",
+    "Derivations",
+    "docs",
+    "Resources",
+]
+
+[lint]
+select = [
+    # https://docs.astral.sh/ruff/rules/unused-import/
+    "F401",
+]


### PR DESCRIPTION
Adds a very basic ruff config to check F401 - unused import rule.

The ruff setup can be extended later.

I added a simple workflow to run pre-commit hooks in CI.