### PR TITLE
Resolve PyVista deprecation warning

### DIFF
--- a/Pynite/Rendering.py
+++ b/Pynite/Rendering.py
@@ -923,7 +923,7 @@ class Renderer:
         v2 = _PerpVector(v1)
         
         # Generate the arc for the moment
-        arc = pv.CircularArcFromNormal(center, resolution=20, normal=v1, angle=215, polar=v2*radius)
+        arc = pv.CircularArcFromNormal(center=center, resolution=20, normal=v1, angle=215, polar=v2*radius)
         
         # Add the arc to the plot
         self.plotter.add_mesh(arc, line_width=2, color=color)


### PR DESCRIPTION
Full warning:
```
  /Users/jonathan/PycharmProjects/pynite/Pynite/Rendering.py:926: PyVistaDeprecationWarning:
  Pynite/Rendering.py:926: Argument 'center' must be passed as a keyword argument to function 'CircularArcFromNormal'.
  From version 0.50, passing this as a positional argument will result in a TypeError.
    arc = pv.CircularArcFromNormal(center, resolution=20, normal=v1, angle=215, polar=v2*radius)
```