### PR TITLE
Add rendering beam local coordinate systems to visualisation modules

### DIFF
--- a/Pynite/Rendering.py
+++ b/Pynite/Rendering.py
@@ -252,7 +252,7 @@ class Renderer:
 
     @property
     def member_csys(self) -> bool:
-        """Scale factor for member local coordinate system visualization."""
+        """Enable or disable rendering of member local coordinate systems."""
         return self._member_csys
 
     @member_csys.setter

--- a/Pynite/Rendering.py
+++ b/Pynite/Rendering.py
@@ -67,6 +67,8 @@ class Renderer:
         self._scalar_bar_text_size: int = 24
         self._member_diagrams: Optional[str] = None  # Options: None, 'Fy', 'Fz', 'My', 'Mz', 'Fx', 'Tx'
         self._diagram_scale: float = 30.0
+        self._member_csys: bool = False
+        self._member_csys_scale: float = 30.0
         self.theme: str = 'default'
 
         # Callback list for post-update customization:
@@ -247,6 +249,24 @@ class Renderer:
     @diagram_scale.setter
     def diagram_scale(self, scale: float) -> None:
         self._diagram_scale = scale
+
+    @property
+    def member_csys(self) -> bool:
+        """Scale factor for member local coordinate system visualization."""
+        return self._member_csys
+
+    @member_csys.setter
+    def member_csys(self, render: bool) -> None:
+        self._member_csys = render
+
+    @property
+    def member_csys_scale(self) -> float:
+        """Scale factor for member local coordinate system visualization."""
+        return self._member_csys_scale
+
+    @member_csys_scale.setter
+    def member_csys_scale(self, scale: float) -> None:
+        self._member_csys_scale = scale
 
     def _calculate_auto_annotation_size(self) -> float:
         """Calculate automatic annotation size as 5% of shortest node distance.
@@ -457,6 +477,9 @@ class Renderer:
         # Render member diagrams if requested
         if self.member_diagrams and (self.combo_name is not None or self.case is not None):
             self.plot_member_diagrams()
+
+        if self.member_csys:
+            self.plot_member_local_csys()
 
         # Determine whether to show or hide the scalar bar
         # if self._scalar_bar == False:
@@ -1657,6 +1680,38 @@ class Renderer:
             except Exception:
                 # Silently skip members that fail to render diagrams
                 pass
+
+    def plot_member_local_csys(self) -> None:
+        for member in self.model.members.values():
+            # Get the member local coordinate axes from the member transformation matrix
+            axes = member.T()[:3, :3]
+            # Plot each one as an arrow at the member centre point
+            centre_point = np.array(
+                [
+                    0.5 * (member.i_node.X + member.j_node.X),
+                    0.5 * (member.i_node.Y + member.j_node.Y),
+                    0.5 * (member.i_node.Z + member.j_node.Z),
+                ]
+            )
+            x_axis = pv.Arrow(
+                start=centre_point,
+                direction=axes[0],
+                scale=self.member_csys_scale / 100,
+            )
+            y_axis = pv.Arrow(
+                start=centre_point,
+                direction=axes[1],
+                scale=self.member_csys_scale / 100,
+            )
+            z_axis = pv.Arrow(
+                start=centre_point,
+                direction=axes[2],
+                scale=self.member_csys_scale / 100,
+            )
+            # Use the same color scheme as PyVista's global coordinate system widget
+            self.plotter.add_mesh(x_axis, color="red")
+            self.plotter.add_mesh(y_axis, color="green")
+            self.plotter.add_mesh(z_axis, color="blue")
 
 
 # === Visualization helper classes ===

--- a/Pynite/Visualization.py
+++ b/Pynite/Visualization.py
@@ -2705,13 +2705,13 @@ def _RenderMemberDiagrams(model, renderer, diagram_type, scale_factor, combo_nam
 class VisLocalCsys:
     """Arrow representation of a member local coordinate system."""
 
-    def __init__(self, position, direction, length, axis, theme: str = "default"):
-        """Create a point-load arrow and optional label.
+    def __init__(self, position, direction, length, axis: str, theme: str = "default"):
+        """Create an arrow representing a member local coordinate system axis.
 
         :param tuple position: Coordinates of the arrow base ``(X, Y, Z)``.
-        :param tuple direction: Direction vector for the arrow (normalized).
-        :param float length: Arrow length; sign controls pointing direction.
-        :param float axis: Which axis we are plotting, one of 'X', 'Y', 'Z'
+        :param tuple direction: Direction vector for the local axis (need not be normalized).
+        :param float length: Visual length of the axis arrow; sign controls pointing direction.
+        :param str axis: Local axis identifier, one of ``'X'``, ``'Y'``, or ``'Z'``.
         :param str theme: ``'default'`` or ``'print'`` color scheme.
         """
 

--- a/Pynite/Visualization.py
+++ b/Pynite/Visualization.py
@@ -255,7 +255,7 @@ class Renderer():
 
     @property
     def member_csys(self) -> bool:
-        """Scale factor for member local coordinate system visualization."""
+        """Toggle rendering of member local coordinate system visualization."""
         return self._member_csys
 
     @member_csys.setter

--- a/Pynite/Visualization.py
+++ b/Pynite/Visualization.py
@@ -64,6 +64,8 @@ class Renderer():
         self._show_load_info = True
         self._member_diagrams = None  # Options: None, 'Fy', 'Fz', 'My', 'Mz', 'Fx', 'Tx'
         self._diagram_scale = 30  # Scale factor for diagram visualization
+        self._member_csys = False
+        self._member_csys_scale = 30
 
         # Initialize VTK objects
         self.renderer = vtk.vtkRenderer()
@@ -250,6 +252,24 @@ class Renderer():
     @diagram_scale.setter
     def diagram_scale(self, value):
         self._diagram_scale = value
+
+    @property
+    def member_csys(self) -> bool:
+        """Scale factor for member local coordinate system visualization."""
+        return self._member_csys
+
+    @member_csys.setter
+    def member_csys(self, render: bool) -> None:
+        self._member_csys = render
+
+    @property
+    def member_csys_scale(self) -> float:
+        """Scale factor for member local coordinate system visualization."""
+        return self._member_csys_scale
+
+    @member_csys_scale.setter
+    def member_csys_scale(self, scale: float) -> None:
+        self._member_csys_scale = scale
 
     def _calculate_auto_annotation_size(self):
         """Calculate automatic annotation size as 5% of shortest node distance.
@@ -544,6 +564,9 @@ class Renderer():
             _RenderContours(self.model, renderer, self.deformed_shape, self.deformed_scale,
                             self.color_map, self.scalar_bar, self.scalar_bar_text_size,
                             self.combo_name, self.theme)
+
+        if self.member_csys:
+            _RenderMemberCsys(self.model, renderer, self.member_csys_scale, self.theme)
 
         # Set the window's background color
         if self.theme == 'default':
@@ -2673,6 +2696,113 @@ def _RenderMemberDiagrams(model, renderer, diagram_type, scale_factor, combo_nam
                 
                 # Add the label actor to the renderer
                 renderer.AddActor(label_actor)
+
+        except Exception:
+            # Skip members that can't create diagrams (e.g., inactive members)
+            pass
+
+
+class VisLocalCsys:
+    """Arrow representation of a member local coordinate system."""
+
+    def __init__(self, position, direction, length, axis, theme: str = "default"):
+        """Create a point-load arrow and optional label.
+
+        :param tuple position: Coordinates of the arrow base ``(X, Y, Z)``.
+        :param tuple direction: Direction vector for the arrow (normalized).
+        :param float length: Arrow length; sign controls pointing direction.
+        :param float axis: Which axis we are plotting, one of 'X', 'Y', 'Z'
+        :param str theme: ``'default'`` or ``'print'`` color scheme.
+        """
+
+        # Create a unit vector in the direction of the 'direction' vector
+        unitVector = direction / norm(direction)
+
+        # Create a 'vtkAppendPolyData' filter to append the tip and shaft together into a single dataset
+        self.polydata = vtk.vtkAppendPolyData()
+
+        # Determine if the load is positive or negative
+        if length == 0:
+            sign = 1
+        else:
+            sign = abs(length) / length
+
+        # Generate the tip of the load arrow
+        tip_length = abs(length) / 4
+        radius = abs(length) / 16
+        tip = vtk.vtkConeSource()
+        tip.SetCenter(
+            position[0] + (length + 0.5 * tip_length) * sign * unitVector[0],
+            position[1] + (length + 0.5 * tip_length) * sign * unitVector[1],
+            position[2] + (length + 0.5 * tip_length) * sign * unitVector[2],
+        )
+        tip.SetDirection(
+            [direction[0] * sign, direction[1] * sign, direction[2] * sign]
+        )
+        tip.SetHeight(tip_length)
+        tip.SetRadius(radius)
+        tip.Update()
+
+        # Add the arrow tip to the append filter
+        self.polydata.AddInputData(tip.GetOutput())
+
+        # Create the shaft
+        shaft = vtk.vtkLineSource()
+        shaft.SetPoint1(position)
+        shaft.SetPoint2(
+            (
+                position[0] + length * unitVector[0],
+                position[1] + length * unitVector[1],
+                position[2] + length * unitVector[2],
+            )
+        )
+        shaft.Update()
+
+        # Copy and append the shaft data to the append filter
+        self.polydata.AddInputData(shaft.GetOutput())
+        self.polydata.Update()
+
+        # Create a mapper and actor
+        mapper = vtk.vtkPolyDataMapper()
+        mapper.SetInputConnection(self.polydata.GetOutputPort())
+        self.actor = vtk.vtkActor()
+
+        # Set the colors to match the theme
+        if theme == "default":
+            if axis == "X":
+                self.actor.GetProperty().SetColor(1, 0, 0)  # Red
+            elif axis == "Y":
+                self.actor.GetProperty().SetColor(0, 1, 0)  # Green
+            else:
+                self.actor.GetProperty().SetColor(0, 0, 1)  # Blue
+        elif theme == "print":
+            if axis == "X":
+                self.actor.GetProperty().SetColor(0.75, 0, 0)  # Dark Red
+            elif axis == "Y":
+                self.actor.GetProperty().SetColor(0, 0.75, 0)  # Dark Green
+            else:
+                self.actor.GetProperty().SetColor(0, 0, 0.75)  # Dark Blue
+
+        self.actor.SetMapper(mapper)
+
+
+def _RenderMemberCsys(model, renderer, scale, theme):
+    for member in model.members.values():
+        try:
+            # Get the member local coordinate axes from the member transformation matrix
+            axes = member.T()[:3, :3]
+            # Plot each one as an arrow at the member centre point
+            centre_point = [
+                0.5 * (member.i_node.X + member.j_node.X),
+                0.5 * (member.i_node.Y + member.j_node.Y),
+                0.5 * (member.i_node.Z + member.j_node.Z),
+            ]
+            x_axis = VisLocalCsys(centre_point, axes[0], scale / 100, "X", theme)
+            renderer.AddActor(x_axis.actor)
+            y_axis = VisLocalCsys(centre_point, axes[1], scale / 100, "Y", theme)
+            renderer.AddActor(y_axis.actor)
+            z_axis = VisLocalCsys(centre_point, axes[2], scale / 100, "Z", theme)
+            renderer.AddActor(z_axis.actor)
 
         except Exception:
             # Skip members that can't create diagrams (e.g., inactive members)

--- a/docs/source/rendering.rst
+++ b/docs/source/rendering.rst
@@ -238,6 +238,22 @@ You can easily switch between different diagram types:
     my_rndr.member_diagrams = None
     my_rndr.render_model()
 
+Member Local Coordinate System
+==================================
+
+You can visualize the individual member local coordinate systems using the ``member_csys`` option to verify that the intended member orientation has been applied correctly. The color scheme is as follows:
+- **Local X axis** (direction from beam start to beam end): Red
+- **Local Y axis** (strong axis): Green
+- **Local Z axis** (weak axis): Blue
+
+.. code-block:: python
+
+    # Activate plotting of member local coordinate systems
+    my_rndr.member_csys = True
+    my_rndr.member_csys_scale = 30      # Adjust diagram size (default: 30)
+    my_rndr.render_model()
+
+
 Rendering the Model and Screenshots
 ===================================
 


### PR DESCRIPTION
This PR adds the ability to render the beam local coordinate systems to both Rendering and Visualization modules, controlled by the `member_csys` and `member_csys_scale` member variables of the renderer classes. The color scheme matches the Vtk default for the global axes widget (x, y, z == red, green, blue)

Addresses #190