### PR TITLE
Clarify the member local coordinate system convention

### DIFF
--- a/docs/source/member.rst
+++ b/docs/source/member.rst
@@ -44,11 +44,23 @@ Local Coordinate System
 Each member starts at its i-node and ends at its j-node. The local x-axis for the member is defined
 by a vector going from the i-node to the j-node.
 
-By default the local z-axis is always horizontal in Pynite, and is on the right-hand side of the
-member.
+By default the local z-axis (typically the member's weak axis) is always parallel to the XZ plane in 
+Pynite, and is on the right-hand side of the member.
+
+Specifically:
+
+- For members parallel to the global y-axis, the local z-axis will be parallel to the global z-axis.
+- For members in the XZ plane, the local y-axis will be parallel to the global y-axis. The member
+  local z-axis is determined by cross product of local x-axis with local y-axis.
+- For other members, the local x-axis is projected into the global XZ plane and the local y-axis is 
+  determined by the cross product of this projected vector and the member local x-axis. The ordering
+  of the cross product is such that the resulting local y-axis has a positive global y component (i.e. 
+  the top of the beam is always pointing in the positive global y direction)
 
 The local y-axis is defined as the cross-product of the local z-axis with the local x-axis. In
 other words, the local y-axis is always perpendicular to the member and to the local z-axis.
+
+The member local coordinate system can be visualised with the ``Renderer.member_csys`` option.
 
 Positive sign conventions are shown below.
 

--- a/docs/source/member.rst
+++ b/docs/source/member.rst
@@ -52,10 +52,10 @@ Specifically:
 - For members parallel to the global y-axis, the local z-axis will be parallel to the global z-axis.
 - For members in the XZ plane, the local y-axis will be parallel to the global y-axis. The member
   local z-axis is determined by cross product of local x-axis with local y-axis.
-- For other members, the local x-axis is projected into the global XZ plane and the local y-axis is 
-  determined by the cross product of this projected vector and the member local x-axis. The ordering
-  of the cross product is such that the resulting local y-axis has a positive global y component (i.e. 
-  the top of the beam is always pointing in the positive global y direction)
+- For other members, the local z-axis is determined by the cross product of the local x-axis
+  projected onto the global XZ plane, and the member local x-axis. The ordering of the cross product
+  is such that the resulting local y-axis has a positive global y component (i.e. the top of the beam
+  is always pointing in the positive global y direction)
 
 The local y-axis is defined as the cross-product of the local z-axis with the local x-axis. In
 other words, the local y-axis is always perpendicular to the member and to the local z-axis.

--- a/docs/source/member.rst
+++ b/docs/source/member.rst
@@ -60,6 +60,9 @@ Specifically:
 The local y-axis is defined as the cross-product of the local z-axis with the local x-axis. In
 other words, the local y-axis is always perpendicular to the member and to the local z-axis.
 
+Rotations are applied by using the right-hand rule, with positive rotations being clockwise if
+looking down the member from the i-node to j-node.
+
 The member local coordinate system can be visualised with the ``Renderer.member_csys`` option.
 
 Positive sign conventions are shown below.

--- a/docs/source/rendering.rst
+++ b/docs/source/rendering.rst
@@ -242,6 +242,7 @@ Member Local Coordinate System
 ==================================
 
 You can visualize the individual member local coordinate systems using the ``member_csys`` option to verify that the intended member orientation has been applied correctly. The color scheme is as follows:
+
 - **Local X axis** (direction from beam start to beam end): Red
 - **Local Y axis** (strong axis): Green
 - **Local Z axis** (weak axis): Blue


### PR DESCRIPTION
Updates the documentation to reflect the logic in `Member3D.T()`

There is also a drive-by fix to a relevant section in rendering.rst, a missing newline broke the rendering of the member local coordinate system section