### PR TITLE
Report deflection for inactive members via linear interpolation (fixes #317)

### DIFF
--- a/Pynite/Member3D.py
+++ b/Pynite/Member3D.py
@@ -1147,6 +1147,40 @@ class Member3D():
         # Return the global displacement vector
         return D
 
+    def _inactive_local_disp(self, combo_name: str = 'Combo 1') -> NDArray[float64]:
+        """
+        Returns the member's local end-displacement vector built from *all* of
+        the nodal degrees of freedom.
+
+        Unlike :meth:`D`, the axial end displacements are always included. This
+        is used by the deflection result methods to describe an inactive
+        member's deflected shape. An inactive member (for example a tension-only
+        member that has gone slack during a tension/compression-only analysis)
+        is removed from the global stiffness matrix and therefore carries no
+        internal forces, but it is still physically connected to its nodes and
+        rides along with them. Its deflected shape is consequently the straight
+        chord between its two displaced end nodes, obtained by linearly
+        interpolating the local end displacements returned here.
+        """
+
+        # Read all six degrees of freedom from each end node
+        D = zeros((12, 1))
+        D[0, 0] = self.i_node.DX[combo_name]
+        D[1, 0] = self.i_node.DY[combo_name]
+        D[2, 0] = self.i_node.DZ[combo_name]
+        D[3, 0] = self.i_node.RX[combo_name]
+        D[4, 0] = self.i_node.RY[combo_name]
+        D[5, 0] = self.i_node.RZ[combo_name]
+        D[6, 0] = self.j_node.DX[combo_name]
+        D[7, 0] = self.j_node.DY[combo_name]
+        D[8, 0] = self.j_node.DZ[combo_name]
+        D[9, 0] = self.j_node.RX[combo_name]
+        D[10, 0] = self.j_node.RY[combo_name]
+        D[11, 0] = self.j_node.RZ[combo_name]
+
+        # Rotate the global displacements into the member's local coordinate system
+        return self.T() @ D
+
     def shear(self, Direction: Literal['Fy', 'Fz'], x: float, combo_name: str = 'Combo 1') -> float:
         """
         Returns the shear at a point along the member's length.
@@ -2352,7 +2386,23 @@ class Member3D():
 
         else:
 
-            return 0
+            # An inactive member carries no internal forces, so it stays straight
+            # between its end nodes rather than bending. It still rides along with
+            # those nodes though, so its deflection is the linear interpolation of
+            # the local end-node displacements rather than zero (see issue #317).
+            d = self._inactive_local_disp(combo_name)
+            L = self.L()
+
+            if Direction == 'dx':
+                di, dj = d[0, 0], d[6, 0]
+            elif Direction == 'dy':
+                di, dj = d[1, 0], d[7, 0]
+            elif Direction == 'dz':
+                di, dj = d[2, 0], d[8, 0]
+            else:
+                raise ValueError(f"Direction must be 'dx', 'dy' or 'dz'. {Direction} was given.")
+
+            return di + (dj - di) * x / L
 
     def max_deflection(self, Direction: Literal['dx', 'dy', 'dz'], combo_tags: Union[str, List[str]] = 'Combo 1') -> Union[float, tuple[float, str]]:
         """
@@ -2600,6 +2650,26 @@ class Member3D():
         else:
             if any(x_array<0) or any(x_array>L):
                 raise ValueError(f"All x values must be in the range 0 to {L}")
+
+        # An inactive member (e.g. a slack tension-only member) carries no
+        # internal forces, so it stays straight between its end nodes instead of
+        # bending. Report the linear interpolation of its end-node displacements,
+        # which it rides along with, rather than a segment-based bending shape
+        # (see issue #317). This mirrors Member3D.deflection().
+        if not self.active[combo_name]:
+
+            d = self._inactive_local_disp(combo_name)
+
+            if Direction == 'dx':
+                di, dj = d[0, 0], d[6, 0]
+            elif Direction == 'dy':
+                di, dj = d[1, 0], d[7, 0]
+            elif Direction == 'dz':
+                di, dj = d[2, 0], d[8, 0]
+            else:
+                raise ValueError(f"Direction must be 'dx', 'dy' or 'dz'. {Direction} was given.")
+
+            return array([x_array, di + (dj - di) * x_array / L])
 
         if P_delta:
             # P-delta analysis is not vectorised yet, do it element-wise

--- a/Pynite/PhysMember.py
+++ b/Pynite/PhysMember.py
@@ -1334,8 +1334,26 @@ class PhysMember(Member3D):
             else:
                 PDelta = False
 
+            # An inactive submember (e.g. a slack tension-only member) carries no
+            # internal forces, so it stays straight between its end nodes rather
+            # than bending. Use the linear interpolation of its end-node
+            # displacements, which it rides along with, instead of a segment-based
+            # bending shape (see issue #317).
+            if not submember.active[combo_name]:
+                d_loc = submember._inactive_local_disp(combo_name)
+                if Direction == 'dx':
+                    di, dj = d_loc[0, 0], d_loc[6, 0]
+                elif Direction == 'dy':
+                    di, dj = d_loc[1, 0], d_loc[7, 0]
+                elif Direction == 'dz':
+                    di, dj = d_loc[2, 0], d_loc[8, 0]
+                else:
+                    raise ValueError(f"Direction must be 'dx', 'dy' or 'dz'. {Direction} was given.")
+                L_subm = submember.L()
+                d_array = array([x_subm_array, di + (dj - di) * x_subm_array / L_subm])
+
             # Check which axis is of interest
-            if Direction == 'dx':
+            elif Direction == 'dx':
                 d_array = self._extract_vector_results(submember.SegmentsZ, x_subm_array, 'axial_deflection')
             elif Direction == 'dy':
                 d_array = self._extract_vector_results(submember.SegmentsZ, x_subm_array, 'deflection', PDelta)

--- a/Testing/test_TC_analysis.py
+++ b/Testing/test_TC_analysis.py
@@ -63,3 +63,66 @@ class Test_2D_Frame(unittest.TestCase):
         self.assertAlmostEqual(tc_model.members['both-ways'].max_axial(), 100, 3)
         self.assertEqual(tc_model.members['t-only bott'].max_axial(), 0, 3)
         self.assertFalse(tc_model.members['t-only bott'].active['Combo 1'])
+
+    def test_inactive_member_deflection(self):
+        """An inactive (slack) tension-only member should still ride along with
+        its nodes: its deflection is the linear interpolation of its end-node
+        displacements rather than zero (issue #317)."""
+
+        from numpy import allclose, diff
+
+        tc_model = FEModel3D()
+        tc_model.add_node('N1', 0, 0, 0)
+        tc_model.add_node('N2', 100, 0, 0)
+        tc_model.add_node('N3', 0, 10, 0)
+        tc_model.add_node('N4', 0, -10, 0)
+
+        tc_model.add_material('Steel', 29000, 11400, 0.3, 0.490/12**2)
+        tc_model.add_section('Section', 1.94, 3, 3, 0.0438)
+
+        tc_model.add_member('both-ways', 'N1', 'N2', 'Steel', 'Section')
+        tc_model.add_member('t-only top', 'N3', 'N2', 'Steel', 'Section', tension_only=True)
+        tc_model.def_releases('t-only top', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
+        tc_model.def_releases('both-ways', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
+
+        tc_model.def_support('N2', *[False]*2, *[True]*4)
+        tc_model.def_support('N1', *[True]*6)
+        tc_model.def_support('N3', *[True]*6)
+        tc_model.def_support('N4', *[True]*6)
+        tc_model.add_node_load('N2', 'FY', -10)
+
+        tc_model.add_member('t-only bott', 'N4', 'N2', 'Steel', 'Section', tension_only=True)
+        tc_model.def_releases('t-only bott', Ryi=True, Rzi=True, Ryj=True, Rzj=True)
+
+        tc_model.analyze()
+
+        member = tc_model.members['t-only bott']
+        L = member.L()
+
+        # The bottom member goes slack (compression) and is removed from the
+        # stiffness matrix, so it carries no internal force.
+        self.assertFalse(member.active['Combo 1'])
+        self.assertEqual(member.max_axial(), 0)
+
+        # The member's local end displacements: the i-end (N4) is fully fixed,
+        # the j-end (N2) deflects under the applied load.
+        d = member._inactive_local_disp('Combo 1')
+        dyi, dyj = d[1, 0], d[7, 0]
+
+        # The j-end actually moves, so this is a non-trivial check.
+        self.assertEqual(dyi, 0.0)
+        self.assertNotAlmostEqual(dyj, 0.0)
+
+        # Deflection at the ends must equal the (local) end-node displacements,
+        # and the interior must be the linear interpolation between them rather
+        # than zero (the old, incorrect behaviour).
+        self.assertAlmostEqual(member.deflection('dy', 0.0), dyi, 9)
+        self.assertAlmostEqual(member.deflection('dy', L), dyj, 9)
+        self.assertAlmostEqual(member.deflection('dy', L/2), 0.5*(dyi + dyj), 9)
+        self.assertNotAlmostEqual(member.deflection('dy', L/2), 0.0)
+
+        # deflection_array must agree with deflection() and be perfectly linear.
+        arr = member.deflection_array('dy', 11)
+        expected = dyi + (dyj - dyi)*arr[0]/L
+        self.assertTrue(allclose(arr[1], expected))
+        self.assertTrue(allclose(diff(arr[1], 2), 0.0, atol=1e-12))


### PR DESCRIPTION
## Summary

Fixes #317. Inactive members — e.g. tension-only members that have gone slack in a tension/compression analysis — are removed from the global stiffness matrix and carry no internal force, but they remain physically connected to their nodes and ride along with them. Between their two displaced end nodes such a member is **straight**, so its deflection at any station is the linear interpolation of its end nodes' displacements.

Currently the deflection of an inactive member is reported incorrectly:

- `Member3D.deflection()` returns `0` for inactive members.
- `Member3D.deflection_array()` and `PhysMember.deflection_array()` build a segment-based bending shape from a local displacement vector whose axial terms `Member3D.D()` zeroes out for inactive members, producing a shape that is neither the true straight-line ride-along nor zero.

## Fix

Added a private helper `Member3D._inactive_local_disp(combo)` that maps the full set of nodal DOFs into the member's local coordinate system, and used it to report the **linear end-node interpolation** for inactive members from:

- `Member3D.deflection()` (else branch)
- `Member3D.deflection_array()` (early return, before the P-Delta path)
- `PhysMember.deflection_array()` (its own per-submember implementation, via an `if not submember.active` branch)

`rel_deflection` correctly stays `0` — the chord-relative deflection of a straight member is zero.

### Why `Member3D.D()` is left unchanged

I deliberately did **not** touch `Member3D.D()`. The pushover seeding path (`FEModel3D.py`) calls `sub_member.f()` unguarded, so changing the zeroing behaviour in `D()` would alter the force history for inactive members during pushover analysis. Keeping the fix in the deflection accessors avoids perturbing the force/reaction/pushover paths. (There is a maintainer `TODO` near `D()` about inactive-member handling — that can be addressed separately if desired.)

## Reproduction & verification

Using the model in `Testing/test_TC_analysis.py`, the tension-only member `t-only bott` (N4→N2) has N4 fully fixed and N2 deflecting. Before the fix its reported deflection is all-zero; after the fix it is the expected straight-line interpolation (`0` at the fixed end ramping to the deflected end).

Added `test_inactive_member_deflection` to `Testing/test_TC_analysis.py` covering this.

The core test suite passes (**116 passed**). The pre-existing optional-dependency test files that fail to collect locally (visualization/vtk/matplotlib backends) are unrelated to this change.
