### PR TITLE
Detect global instability via the solution residual (fixes #255, #275)

### DIFF
--- a/Pynite/Analysis.py
+++ b/Pynite/Analysis.py
@@ -2,8 +2,10 @@ from __future__ import annotations  # Allows more recent type hints features
 from typing import TYPE_CHECKING
 from math import isclose
 
-from numpy import array, atleast_2d, zeros, subtract, matmul, divide, seterr, nanmax
-from numpy.linalg import solve
+import warnings
+
+from numpy import array, atleast_2d, zeros, subtract, matmul, divide, seterr, nanmax, asarray, isfinite
+from numpy.linalg import solve, norm
 
 from Pynite.LoadCombo import LoadCombo
 
@@ -166,16 +168,69 @@ def _check_stability(model: FEModel3D, K: NDArray[float64]) -> None:
     return
 
 
+# Exception message shared by the global-instability checks below
+_SINGULAR_MSG = ('The stiffness matrix is singular, which implies rigid body motion. The structure '
+                 'is unstable. Aborting analysis.')
+
+
+def _solve_unknown_disp(K11, rhs, sparse: bool = True, check_stability: bool = True, tol: float = 1e-6):
+    """Solves ``K11 @ x = rhs`` for the unknown displacements, raising on a singular stiffness matrix.
+
+    The nodal stability check (:func:`_check_stability`) only catches degrees of freedom with a zero
+    stiffness on the diagonal. It does not catch *global* instability, where every diagonal term is
+    non-zero but the assembled matrix is still rank-deficient -- for example a mechanism created by
+    member end releases (a beam with an internal hinge and no support there), or a structure with
+    insufficient supports (rigid body motion). In those cases the underlying solvers do not reliably
+    report the problem: ``scipy.sparse.linalg.spsolve`` may return ``NaN`` (with only a
+    ``MatrixRankWarning``) or even finite-but-meaningless values, and ``numpy.linalg.solve`` may miss
+    the singularity due to floating point round-off. The model then silently reports erroneous
+    results.
+
+    When ``check_stability`` is ``True`` the computed displacements are verified against equilibrium
+    by measuring the relative residual ``||K11 @ x - rhs|| / ||rhs||``. A stable structure -- even a
+    numerically ill-conditioned one -- solves to within round-off (the direct solvers are backward
+    stable), whereas a singular system yields ``NaN``/``inf`` or finite values with an O(1) residual.
+    This residual test is therefore a robust indicator of global instability that, unlike inspecting
+    the factorization's pivot magnitudes, does not misclassify legitimately ill-conditioned but
+    stable models. When ``check_stability`` is ``False`` the bare solvers are used unchanged.
+
+    :param K11: The partitioned stiffness matrix for the unknown displacements (square, ``n``x``n``).
+    :param rhs: The right-hand side vector (shape ``(n, 1)``).
+    :param sparse: Whether ``K11`` is a SciPy sparse matrix. Defaults to ``True``.
+    :param check_stability: Whether to check for global instability after solving. Defaults to ``True``.
+    :param tol: Relative residual above which the matrix is treated as singular. Defaults to ``1e-6``.
+    :raises Exception: If the stiffness matrix is singular (the structure is unstable).
+    :return: The solved displacement vector, shape ``(n, 1)``.
+    """
+
+    if sparse:
+        from scipy.sparse.linalg import spsolve
+
+        K = K11.tocsr()
+        # A singular matrix makes `spsolve` emit a `MatrixRankWarning`; we detect that case below via
+        # the residual/finiteness check and raise a descriptive error, so suppress the bare warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            x = spsolve(K, rhs)
+        x = x.reshape(len(x), 1)
+    else:
+        K = asarray(K11, dtype=float)
+        x = solve(K, rhs)
+
+    if check_stability:
+        rhs_norm = norm(rhs)
+        if not isfinite(x).all() or (rhs_norm > 0 and norm(K @ x - rhs) > tol * rhs_norm):
+            raise Exception(_SINGULAR_MSG)
+
+    return x
+
+
 def _first_order(model: FEModel3D, combo_name: str, P1: NDArray[float64], FER1: NDArray[float64], D1_indices: List[int], D2_indices: List[int], D2: NDArray[float64], log: bool = True, sparse: bool = True, check_stability: bool = False, max_iter: int = 30, spring_tolerance: float = 0, member_tolerance: float = 0, num_steps: int = 1) -> None:
     """Performs the shared first-order elastic/tension-compression-only solution path.
 
     This helper is used by both ``FEModel3D.analyze`` and pushover preload so the normal
     first-order workflow lives in one place.
     """
-
-    # Import `scipy` features if the sparse solver is being used
-    if sparse == True:
-        from scipy.sparse.linalg import spsolve
 
     # Calculate the incremental enforced displacement vector
     Delta_D2 = D2/num_steps
@@ -218,15 +273,15 @@ def _first_order(model: FEModel3D, combo_name: str, P1: NDArray[float64], FER1: 
                 Delta_D1 = []
             else:
                 try:
-                    # Calculate the unknown displacements Delta_D1
+                    # Calculate the unknown displacements Delta_D1. The partitioned stiffness matrix
+                    # originates as `coo` and is converted to `csr`/`csc` for mathematical operations.
+                    # `_solve_unknown_disp` also detects global instability (a singular matrix) that
+                    # the bare solvers can silently miss.
                     if sparse == True:
-                        # The partitioned stiffness matrix originates as `coo` and is converted to `csr`
-                        # format for mathematical operations. The `@` operator performs matrix multiplication
-                        # on sparse matrices.
-                        Delta_D1 = spsolve(K11, subtract(subtract(Delta_P1, Delta_FER1), K12 @ Delta_D2))
-                        Delta_D1 = Delta_D1.reshape(len(Delta_D1), 1)
+                        rhs = subtract(subtract(Delta_P1, Delta_FER1), K12 @ Delta_D2)
                     else:
-                        Delta_D1 = solve(K11, subtract(subtract(Delta_P1, Delta_FER1), matmul(K12, Delta_D2)))
+                        rhs = subtract(subtract(Delta_P1, Delta_FER1), matmul(K12, Delta_D2))
+                    Delta_D1 = _solve_unknown_disp(K11, rhs, sparse, check_stability)
                 except:
                     # Return out of the method if 'K' is singular and provide an error message
                     raise Exception('The stiffness matrix is singular, which implies rigid body motion. The structure is unstable. Aborting analysis.')

--- a/Pynite/FEModel3D.py
+++ b/Pynite/FEModel3D.py
@@ -2266,10 +2266,6 @@ class FEModel3D():
             print('| Analyzing: Linear |')
             print('+-------------------+')
 
-        # Import `scipy` features if the sparse solver is being used
-        if sparse == True:
-            from scipy.sparse.linalg import spsolve
-
         # Prepare the model for analysis
         Analysis._prepare_model(self)
 
@@ -2308,15 +2304,15 @@ class FEModel3D():
                 D1 = []
             else:
                 try:
-                    # Calculate the unknown displacements D1
+                    # Calculate the unknown displacements D1. The partitioned stiffness matrix
+                    # originates as `coo` and is converted to `csr`/`csc` for mathematical
+                    # operations. `_solve_unknown_disp` also detects global instability (a singular
+                    # matrix) that the bare solvers can silently miss.
                     if sparse == True:
-                        # The partitioned stiffness matrix originates as `coo` and is converted
-                        # to `csr` format for mathematical operations. The `@` operator performs
-                        # matrix multiplication on sparse matrices.
-                        D1 = spsolve(K11.tocsr(), np.subtract(np.subtract(P1, FER1), K12.tocsr() @ D2))
-                        D1 = D1.reshape(len(D1), 1)
+                        rhs = np.subtract(np.subtract(P1, FER1), K12.tocsr() @ D2)
                     else:
-                        D1 = solve(K11, np.subtract(np.subtract(P1, FER1), np.matmul(K12, D2)))
+                        rhs = np.subtract(np.subtract(P1, FER1), np.matmul(K12, D2))
+                    D1 = Analysis._solve_unknown_disp(K11, rhs, sparse, check_stability)
                 except:
                     # Return out of the method if 'K' is singular and provide an error message
                     raise Exception('The stiffness matrix is singular, which implies rigid body motion. The structure is unstable. Aborting analysis.')

--- a/Testing/test_instability.py
+++ b/Testing/test_instability.py
@@ -1,0 +1,115 @@
+# Tests for detection of global instability (a singular stiffness matrix).
+#
+# These cover GitHub issues #255 ("No error is thrown on unstable model in some scenarios") and
+# #275 ("Model produces results when unstable with a hinge"), where a globally unstable model
+# (a mechanism or a structure with insufficient supports) was silently solved and returned
+# erroneous reactions/displacements instead of raising. The nodal stability check only catches
+# degrees of freedom with zero diagonal stiffness; these models are globally rank-deficient while
+# every diagonal term is non-zero.
+
+import unittest
+
+from Pynite import FEModel3D
+
+
+class TestInstabilityDetection(unittest.TestCase):
+    """Globally unstable models must raise, while stable models must still solve."""
+
+    def test_hinge_mechanism_raises_sparse(self):
+        # Issue #275: a two-span beam joined by an internal hinge with no support at the hinge is a
+        # mechanism. Both the dense and sparse solvers previously returned erroneous finite results.
+        model = self._hinge_mechanism()
+        with self.assertRaises(Exception):
+            model.analyze(sparse=True, check_statics=False)
+
+    def test_hinge_mechanism_raises_dense(self):
+        model = self._hinge_mechanism()
+        with self.assertRaises(Exception):
+            model.analyze(sparse=False, check_statics=False)
+
+    def test_unsupported_member_raises(self):
+        # Issue #255, scenario 1: a single member with no supports (six rigid body modes).
+        for sparse in (True, False):
+            model = FEModel3D()
+            model.add_node('N1', 0, 0, 0)
+            model.add_node('N2', 0, 1, 0)
+            model.add_material('Steel', 29000, 11400, 0.5, 490 / 1000 / 12**3)
+            model.add_section('Section', 10, 100, 150, 250)
+            model.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
+            with self.assertRaises(Exception):
+                model.analyze(sparse=sparse, check_statics=False)
+
+    def test_unsupported_frame_raises(self):
+        # Issue #255, scenario 2: an unsupported frame loaded in-plane. The sparse solver previously
+        # returned finite-but-meaningless displacements with no warning at all.
+        for sparse in (True, False):
+            model = FEModel3D()
+            model.add_node('N1', 0, 0, 0)
+            model.add_node('N2', 0, 144, 0)
+            model.add_node('N3', 180, 144, 0)
+            model.add_node('N4', 180, 0, 0)
+            model.add_material('Steel', 29000, 11400, 0.5, 490 / 1000 / 12**3)
+            model.add_section('Section', 10, 100, 150, 250)
+            model.add_section('Section2', 15, 100, 250, 250)
+            model.add_member('M1', 'N1', 'N2', 'Steel', 'Section')
+            model.add_member('M2', 'N4', 'N3', 'Steel', 'Section')
+            model.add_member('M3', 'N2', 'N3', 'Steel', 'Section2')
+            model.add_node_load('N2', 'FX', 50)
+            with self.assertRaises(Exception):
+                model.analyze(sparse=sparse, check_statics=False)
+
+    def test_stable_model_still_solves(self):
+        # A stable propped cantilever must analyze normally and give the correct reaction (the fixed
+        # end of a propped cantilever under a uniform load w over length L carries 5*w*L/8).
+        for sparse in (True, False):
+            model = self._propped_cantilever()
+            model.analyze(sparse=sparse, check_statics=False)
+            self.assertAlmostEqual(model.nodes['n1'].RxnFY['Combo 1'], 6.25, places=4)
+
+    def test_check_stability_false_skips_check(self):
+        # With ``check_stability=False`` the stability check is bypassed (the historical fast path),
+        # so an unstable model does not raise from the stability check.
+        model = self._hinge_mechanism()
+        try:
+            model.analyze(sparse=True, check_stability=False, check_statics=False)
+        except Exception:
+            # It is acceptable for the bare solver to fail on its own, but it must NOT be blocked by
+            # our stability check. Re-running the stable model with the flag off must succeed.
+            pass
+        stable = self._propped_cantilever()
+        stable.analyze(sparse=True, check_stability=False, check_statics=False)
+        self.assertAlmostEqual(stable.nodes['n1'].RxnFY['Combo 1'], 6.25, places=4)
+
+    @staticmethod
+    def _hinge_mechanism():
+        model = FEModel3D()
+        model.add_section('W10x33', 0.006264504, 0.000015234, 0.0000712, 0.000000241)
+        model.add_material('steel', 200000000, 77000000, 0.3, 77)
+        model.add_node('n1', 0, 0, 0)
+        model.add_node('n2', 1, 0, 0)
+        model.add_node('n3', 2, 0, 0)
+        model.add_member('m1', 'n1', 'n2', 'steel', 'W10x33')
+        model.add_member('m2', 'n2', 'n3', 'steel', 'W10x33')
+        model.def_support('n1', 1, 1, 1, 1, 1, 0)
+        model.def_support('n3', 0, 1, 1, 1, 1, 0)
+        model.add_member_dist_load('m1', 'Fy', 10, 10)
+        model.add_member_dist_load('m2', 'Fy', 10, 10)
+        model.def_releases('m2', Rzi=True)
+        return model
+
+    @staticmethod
+    def _propped_cantilever():
+        model = FEModel3D()
+        model.add_node('n1', 0, 0, 0)
+        model.add_node('n2', 10, 0, 0)
+        model.add_material('steel', 29000, 11200, 0.3, 0.284)
+        model.add_section('S', 10, 100, 150, 250)
+        model.add_member('m', 'n1', 'n2', 'steel', 'S')
+        model.def_support('n1', 1, 1, 1, 1, 1, 1)
+        model.def_support('n2', 0, 1, 1, 0, 0, 0)
+        model.add_member_dist_load('m', 'Fy', -1, -1)
+        return model
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #255 and #275. A globally **unstable** model — a mechanism (e.g. a beam with an internal hinge and no support at the hinge) or a structure with insufficient supports (rigid-body motion) — has a *singular* global stiffness matrix even though every diagonal term is non-zero. `analyze()` currently solves it anyway and silently returns erroneous reactions, shears, moments and displacements instead of raising.

The existing nodal stability check (`Analysis._check_stability`) only inspects the diagonal for unsupported zero-stiffness DOFs, so it cannot see this kind of *global* rank deficiency. The underlying solvers don't reliably report it either:

- `scipy.sparse.linalg.spsolve` returns `NaN` (with only a `MatrixRankWarning`), or in some cases finite-but-meaningless displacements with **no warning at all** (#255 scenario 2).
- `numpy.linalg.solve` can miss the singularity due to round-off (#255 scenario 3), and neither solver flags the hinge mechanism of #275.

## Approach

I add `Analysis._solve_unknown_disp(K11, rhs, sparse, check_stability)`, which solves for the unknown displacements and, when `check_stability` is enabled, **verifies the solution against equilibrium** using the relative residual `‖K11·x − rhs‖ / ‖rhs‖`. A stable structure — even a numerically ill-conditioned one — solves to within round-off because the direct solvers are backward-stable, whereas a singular system yields a non-finite or O(1)-residual result.

I first tried the natural pivot-magnitude / rank approach (factorize and compare the smallest LU pivot to the largest). It is **not sound for this codebase**: several stable models in the existing test suite (e.g. the Kassimali 2D frame, and the mat-foundation / plate meshes) have a smallest-to-largest pivot ratio already down at ≈1e-17, indistinguishable from a genuine mechanism, so any pivot threshold misclassifies them. Measured across the suite, the worst stable relative *residual* is ≈2.4e-13, while the unstable models from #255/#275 give residuals of order 1 — a clean ~13-order-of-magnitude separation. The default tolerance is `1e-6`.

The check is cheap (one matrix–vector product plus two norms, no extra factorization) and gated on the existing `check_stability` flag, so the historical fast path is preserved when it is disabled.

## Scope

The first-order elastic / tension-compression path (`Analysis._first_order`, used by `analyze()`) and the linear path (`FEModel3D.analyze_linear`) now route through the helper. The P-Delta and pushover paths are intentionally left unchanged — they deliberately drive the structure toward buckling (where the tangent stiffness approaches singular by design), so a hard instability raise there would need separate, buckling-aware handling.

## Reproduction & verification

All four reported scenarios now raise `The stiffness matrix is singular ...` instead of returning results, for both the sparse and dense solvers:

- #275: simply-supported two-span beam joined by an internal hinge with no support at the hinge.
- #255 scenario 1: a single unsupported member.
- #255 scenario 2: an unsupported frame loaded in-plane (previously returned finite garbage with no warning).
- #255 scenario 3: an unsupported closed frame solved with `sparse=False`.

Added `Testing/test_instability.py` covering the hinge mechanism and the unsupported-model scenarios (sparse and dense), that a stable propped cantilever still solves to the correct reaction (`5wL/8`), and that `check_stability=False` bypasses the check.

The full core test suite passes (the optional-dependency test files for the visualization/VTK backends fail to *collect* locally for unrelated reasons and were excluded): **121 passed** (115 existing + 6 new), with no regressions.
