### PR TITLE
Fix report generation for models with quads and plates (fixes #268)

### DIFF
--- a/Pynite/Report_Template.html
+++ b/Pynite/Report_Template.html
@@ -393,29 +393,29 @@
                 <tr>
                     <td>{{ plate.name }}</td>
                     <td>{{ combo.name }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(0, 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(0, 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(0, 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(0, 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(0, 0, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(0, 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(0, 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(0, 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(0, 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(0, 0, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(plate.shear(0, plate.height(), combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(0, plate.height(), combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(0, plate.height(), combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(0, plate.height(), combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(0, plate.height(), combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(0, plate.height(), combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(0, plate.height(), combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(0, plate.height(), combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(0, plate.height(), combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(0, plate.height(), combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(plate.shear(plate.width(), plate.height(), combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(plate.width(), plate.height(), combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width(), plate.height(), combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width(), plate.height(), combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width(), plate.height(), combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(plate.width(), plate.height(), combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(plate.width(), plate.height(), combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width(), plate.height(), combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width(), plate.height(), combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width(), plate.height(), combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(plate.shear(plate.width(), 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(plate.width(), 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width(), 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width(), 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width(), 0, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(plate.width(), 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(plate.width(), 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width(), 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width(), 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width(), 0, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
 
@@ -423,29 +423,29 @@
                 <tr>
                     <td>{{ quad.name }}</td>
                     <td>{{ combo.name }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(-1, -1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(-1, -1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(-1, -1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(-1, -1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(-1, -1, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(-1, -1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(-1, -1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(-1, -1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(-1, -1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(-1, -1, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(quad.shear(1, -1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(1, -1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(1, -1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(1, -1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(1, -1, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(1, -1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(1, -1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(1, -1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(1, -1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(1, -1, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(quad.shear(1, 1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(1, 1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(1, 1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(1, 1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(1, 1, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(1, 1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(1, 1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(1, 1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(1, 1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(1, 1, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(quad.shear(-1, 1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(-1, 1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(-1, 1, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(-1, 1, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(-1, 1, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(-1, 1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(-1, 1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(-1, 1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(-1, 1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(-1, 1, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
             {% endfor %}
@@ -477,11 +477,11 @@
                 <tr>
                     <td>{{ plate.name }}</td>
                     <td>{{ combo.name }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(plate.width()/2, plate.height()/2, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.shear(plate.width()/2, plate.height()/2, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width()/2, plate.height()/2, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width()/2, plate.height()/2, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.moment(plate.width()/2, plate.height()/2, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(plate.width()/2, plate.height()/2, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.shear(plate.width()/2, plate.height()/2, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width()/2, plate.height()/2, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width()/2, plate.height()/2, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.moment(plate.width()/2, plate.height()/2, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
 
@@ -489,11 +489,11 @@
                 <tr>
                     <td>{{ quad.name }}</td>
                     <td>{{ combo.name }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(0, 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.shear(0, 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(0, 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(0, 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.moment(0, 0, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(0, 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.shear(0, 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(0, 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(0, 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.moment(0, 0, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
 
@@ -543,21 +543,21 @@
                     <td>{{ plate.name }}</td>
                     <td>{{ combo.name }}</td>
 
-                    <td>{{ "%.3g" | format(plate.membrane(0, 0, combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(0, 0, combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(0, 0, combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(0, 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(0, 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(0, 0, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(plate.membrane(0, plate.height(), combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(0, plate.height(), combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(0, plate.height(), combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(0, plate.height(), combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(0, plate.height(), combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(0, plate.height(), combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), plate.height(), combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), plate.height(), combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), plate.height(), combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), plate.height(), combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), plate.height(), combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), plate.height(), combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), 0, combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), 0, combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), 0, combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width(), 0, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
 
@@ -566,21 +566,21 @@
                     <td>{{ quad.name }}</td>
                     <td>{{ combo.name }}</td>
 
-                    <td>{{ "%.3g" | format(quad.membrane(-1, -1, combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(-1, -1, combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(-1, -1, combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(-1, -1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(-1, -1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(-1, -1, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(quad.membrane(1, -1, combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(1, -1, combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(1, -1, combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(1, -1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(1, -1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(1, -1, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(quad.membrane(1, 1, combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(1, 1, combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(1, 1, combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(1, 1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(1, 1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(1, 1, combo_name=combo.name)[2][0]) }}</td>
 
-                    <td>{{ "%.3g" | format(quad.membrane(-1, 1, combo.name)[0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(-1, 1, combo.name)[1]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(-1, 1, combo.name)[2]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(-1, 1, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(-1, 1, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(-1, 1, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
             {% endfor %}
@@ -608,9 +608,9 @@
                 <tr>
                     <td>{{ plate.name }}</td>
                     <td>{{ combo.name }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width()/2, plate.height()/2, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width()/2, plate.height()/2, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(plate.membrane(plate.width()/2, plate.height()/2, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width()/2, plate.height()/2, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width()/2, plate.height()/2, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(plate.membrane(plate.width()/2, plate.height()/2, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
 
@@ -618,9 +618,9 @@
                 <tr>
                     <td>{{ quad.name }}</td>
                     <td>{{ combo.name }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(0, 0, combo.name)[0][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(0, 0, combo.name)[1][0]) }}</td>
-                    <td>{{ "%.3g" | format(quad.membrane(0, 0, combo.name)[2][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(0, 0, combo_name=combo.name)[0][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(0, 0, combo_name=combo.name)[1][0]) }}</td>
+                    <td>{{ "%.3g" | format(quad.membrane(0, 0, combo_name=combo.name)[2][0]) }}</td>
                 </tr>
                 {% endfor %}
 

--- a/Testing/test_reporting.py
+++ b/Testing/test_reporting.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the HTML reporting module (Pynite.Reporting).
+
+Covers issue #268: generating a report for a model containing quads/plates
+raised ``KeyError: 'Combo 1'`` because the report template passed the load
+combination name into the elements' ``local`` argument instead of
+``combo_name`` (leaving ``combo_name`` at its default ``'Combo 1'``, which was
+never analyzed). A second, related template bug indexed the ``(3, 1)`` membrane
+result as ``[n]`` instead of ``[n][0]``.
+"""
+
+import os
+import tempfile
+import unittest
+
+from Pynite import FEModel3D
+
+try:
+    import jinja2  # noqa: F401
+
+    from Pynite import Reporting
+
+    HAS_JINJA = True
+except ImportError:
+    HAS_JINJA = False
+
+
+def _build_model() -> FEModel3D:
+    """A supported quad + plate under pressure, analyzed for a single custom
+    load combination so the default ``'Combo 1'`` is never solved."""
+    model = FEModel3D()
+    model.add_material("Steel", 29000, 11200, 0.3, 0.284)
+
+    # Quad nodes
+    model.add_node("N1", 0, 0, 0)
+    model.add_node("N2", 10, 0, 0)
+    model.add_node("N3", 10, 10, 0)
+    model.add_node("N4", 0, 10, 0)
+    model.add_quad("Q1", "N1", "N2", "N3", "N4", 0.25, "Steel")
+
+    # Plate nodes (offset so it is a separate element)
+    model.add_node("N5", 10, 0, 0)
+    model.add_node("N6", 20, 0, 0)
+    model.add_node("N7", 20, 10, 0)
+    model.add_node("N8", 10, 10, 0)
+    model.add_plate("P1", "N5", "N6", "N7", "N8", 0.25, "Steel")
+
+    for n in ("N1", "N2", "N3", "N4", "N5", "N6", "N7", "N8"):
+        model.def_support(n, True, True, True, True, True, True)
+
+    model.add_quad_surface_pressure("Q1", 0.1, case="D")
+    model.add_plate_surface_pressure("P1", 0.1, case="D")
+
+    # Only a custom-named combo is analyzed; the default 'Combo 1' is not.
+    model.add_load_combo("1.4D", {"D": 1.4})
+    model.analyze_linear(check_statics=False)
+    return model
+
+
+@unittest.skipUnless(HAS_JINJA, "reporting extra (Jinja2) not installed")
+class TestReporting(unittest.TestCase):
+    def test_report_with_quads_and_plates(self) -> None:
+        """create_report must not raise KeyError 'Combo 1' (issue #268)."""
+        model = _build_model()
+        out = os.path.join(tempfile.mkdtemp(), "report.html")
+
+        # Must not raise (previously raised KeyError: 'Combo 1').
+        Reporting.create_report(model, format="html", output_filepath=out)
+
+        self.assertTrue(os.path.exists(out))
+        html = open(out, encoding="utf-8").read()
+        # The analyzed combo is reported, and the unanalyzed default is absent.
+        self.assertIn("1.4D", html)
+        self.assertNotIn("Combo 1", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the remaining reporting breakage from #268 (the quad/plate case @boustrephon reported, which was never addressed).

## Problem

`Reporting.create_report()` raises `KeyError: 'Combo 1'` for **any** model containing quads or plates — e.g. `Examples/Shear Wall - Advanced.py`:

```python
from Pynite import Reporting
Reporting.create_report(model, format='html', output_filepath='./ModelReport.html')
# KeyError: 'Combo 1'  (in Quad3D.D -> self.i_node.DX[combo_name])
```

## Root cause

`Quad3D`/`Plate3D` `shear()`, `moment()` and `membrane()` all have the signature

```python
def shear(self, xi=0.0, eta=0.0, local=True, combo_name='Combo 1'): ...
```

The report template called them as `quad.shear(-1, -1, combo.name)` — so the combo name was bound to **`local`**, and `combo_name` kept its default `'Combo 1'`. Since most models never analyze the default `'Combo 1'`, the subsequent `node.DX['Combo 1']` lookup raised `KeyError`. (The `member.*` calls are unaffected — their third positional arg genuinely is `combo_name`.)

A second, latent template bug was masked behind the first: `membrane()` returns a `(3, 1)` column vector, but several cells indexed it as `[n]` instead of `[n][0]`, leaving a 1-element array that the `"%.3g" | format(...)` filter cannot render (`TypeError: only 0-dimensional arrays can be converted to Python scalars`).

## Fix

- Pass `combo_name=combo.name` as a keyword on every `plate`/`quad` `shear`/`moment`/`membrane` call (80 sites) so `local` keeps its intended default.
- Normalize membrane result indexing to `[n][0]` (24 sites), matching `shear`/`moment` and the already-correct membrane cells.

Template-only change — no solver code touched.

## Verification

- `Examples/Shear Wall - Advanced.py` + `create_report(...)` now renders a complete 8 MB HTML report (previously raised immediately).
- New `Testing/test_reporting.py`: builds a supported quad **and** plate under pressure, analyzes a single custom-named combo (`1.4D`) so the default `Combo 1` is never solved, generates the HTML report, and asserts it does not raise, that the analyzed combo appears, and that `Combo 1` does not. The test **fails on `main`** (`KeyError: 'Combo 1'`) and passes with this change.
- Beam-only reports (no quads/plates) still render unchanged.
- Full core suite: **116 passed** (115 + the new test).

Note: #268 originally bundled three problems; the first two were resolved in v1.2.0 / v1.5.0, and this addresses the last outstanding one. Happy to retarget to a dedicated issue number if you'd prefer.