### PR TITLE
Fix Pushover Analysis Example

### DIFF
--- a/Examples/Moment Frame - Pushover.py
+++ b/Examples/Moment Frame - Pushover.py
@@ -82,9 +82,9 @@ frame.add_load_combo('Pushover', {'Push': 0.01})
 # combo results for each load combo and load step. Traces are an optional feature for pushover
 # analysis intended to help visualize the progression of key response quantities.
 traces = {
-    'Node d Drift': lambda combo_name: frame.nodes['d'].DX[combo_name]*12,
-    'Moment at c:': lambda combo_name: frame.members['bd'].moment('Mz', x=20.0, combo_name=combo_name),
-    'Moment at d:': lambda combo_name: frame.members['bd'].moment('Mz', x=60.0, combo_name=combo_name),
+    'Node d Drift': lambda combo_name, frame=frame: frame.nodes['d'].DX[combo_name]*12,
+    'Moment at c:': lambda combo_name, frame=frame: frame.members['bd'].moment('Mz', x=20.0, combo_name=combo_name),
+    'Moment at d:': lambda combo_name, frame=frame: frame.members['bd'].moment('Mz', x=60.0, combo_name=combo_name),
 }
 
 # Analyze the model

--- a/Examples/Pushover Analysis.py
+++ b/Examples/Pushover Analysis.py
@@ -67,9 +67,9 @@ control_limit = -6.0
 # combo results for each load combo and load step. Traces are an optional feature for pushover
 # analysis intended to help visualize the progression of key response quantities.
 traces = {
-    'Fixed End Moment': lambda combo_name: plastic_beam.members['M1'].moment('Mz', x=0.0, combo_name=combo_name),
-    'Load Point Moment': lambda combo_name: plastic_beam.members['M1'].moment('Mz', x=96.0, combo_name=combo_name),
-    'Load Point Deflection': lambda combo_name: plastic_beam.nodes['N2'].DY[combo_name],
+    'Fixed End Moment': lambda combo_name, plastic_beam=plastic_beam: plastic_beam.members['M1'].moment('Mz', x=0.0, combo_name=combo_name),
+    'Load Point Moment': lambda combo_name, plastic_beam=plastic_beam: plastic_beam.members['M1'].moment('Mz', x=96.0, combo_name=combo_name),
+    'Load Point Deflection': lambda combo_name, plastic_beam=plastic_beam: plastic_beam.nodes['N2'].DY[combo_name],
 }
 
 # Analyze the model


### PR DESCRIPTION
Pass `plastic_beam` in via a default argument to avoid a `NameError` when called in another module during analysis.

Lambda functions only have access to the scope of the environment they are called in. Any additional variables from where they are defined must be explicitly passed in.

Resolves #325