### PR TITLE
Update GHA dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,10 +18,10 @@ jobs:
         python-version: ['3.11', '3.13']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -51,10 +51,9 @@ jobs:
         coverage xml -o .coverage.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v7
       with:
         file: .coverage.xml
         flags: unittests
         name: codecov-coverage
         token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
Updates outdated external GHA dependencies

Two notes:
* These type of dependency updates can be automated with [Renovate](https://docs.renovatebot.com/)
* Both of the existing workflows are missing some common security practices. Those can be detected and fixed by [zizmor](https://docs.zizmor.sh/)