### PR TITLE
Document lint setup for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,29 @@ Run tests using `pytest`.
 ```bash
 pytest
 ```
+
+## Linting
+
+Linting is handled by [ruff](https://docs.astral.sh/ruff/), with hooks managed by [prek](https://github.com/j178/prek). The rules live in `ruff.toml`, and currently only check for unused imports (F401).
+
+Install prek outside the project environment, so that git GUI clients can run the hooks without activating a virtualenv:
+
+```bash
+uv tool install prek
+```
+
+`pipx install prek` works too. Then install the git hook:
+
+```bash
+prek install
+```
+
+The configured checks now run against your staged files on every commit, fixing what they can. To run them across the whole repository:
+
+```bash
+prek run --all-files
+```
+
+The same checks run in CI on every pull request.
+
+prek reads `.pre-commit-config.yaml`, which is the standard pre-commit config format, so stock `pre-commit` works against the same config if you already use it. If you want ruff in your editor, install it separately and match the version pinned in `.pre-commit-config.yaml` so it reports the same results as the hook.


### PR DESCRIPTION
Follow-up to #299, and **should merge after it** — the `## Linting` section references `ruff.toml` and `.pre-commit-config.yaml`, which that PR adds.

#299 adds a `lint` CI check, but nothing tells contributors it exists. `requirements.txt` listed only `pytest` under `# Development`, and CONTRIBUTING.md had no linting section at all. As it stands someone can clone, commit, and get a red check from tooling they were never pointed at, with no local hook installed.

This adds:

- `ruff` and `prek` to the development requirements
- A `## Linting` section after `## Testing` covering the hook install, running ruff directly, and a note that stock `pre-commit` works against the same config for anyone who already uses it

I verified every command against a tree with #299 merged in: `prek install` writes the hook, `ruff check --fix .` picks up `ruff.toml`, and committing a file with an unused import triggers the hook, which blocks the commit and reports the fix it made.